### PR TITLE
Magic contour selection

### DIFF
--- a/src/fontra/client/core/path-hit-tester.js
+++ b/src/fontra/client/core/path-hit-tester.js
@@ -62,7 +62,7 @@ export class PathHitTester {
       }
     }
 
-    results = results.filter((hit) => hit.t != 0 && hit.t != 1);
+    // results = results.filter((hit) => hit.t != 0 && hit.t != 1);
     results.sort((a, b) => a.d - b.d);
     return results[0];
   }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -58,7 +58,7 @@ export class PointerTool extends BaseTool {
     sceneController.hoverSelection = selection;
     sceneController.hoveredGlyph = undefined;
     sceneController.hoverPathHit = pathHit;
-    sceneController.magicSelection = [];
+    sceneController.magicSelectionHit = [];
 
     if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
       sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
@@ -138,7 +138,7 @@ export class PointerTool extends BaseTool {
     point.y -= positionedGlyph.y;
     const pathHitTester = glyphController.flattenedPathHitTester;
     const nearestHit = pathHitTester.findNearest(point);
-    sceneController.magicSelection = [point.x, point.y, nearestHit.x, nearestHit.y];
+    sceneController.magicSelectionHit = [point.x, point.y, nearestHit.x, nearestHit.y];
     return nearestHit;
   }
 

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -124,10 +124,10 @@ export class PointerTool extends BaseTool {
         newSelection.add(`point/${i}`);
       }
     }
-    const sselection = this._selectionBeforeSingleClick || sceneController.selection;
+    const selection = this._selectionBeforeSingleClick || sceneController.selection;
     this._selectionBeforeSingleClick = undefined;
     const modeFunc = selectModeFunction(event);
-    sceneController.selection = modeFunc(sselection, newSelection);
+    sceneController.selection = modeFunc(selection, newSelection);
   }
 
   getNearestHit(sceneController, event, glyphController) {

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -142,6 +142,8 @@ export class PointerTool extends BaseTool {
       sceneController.magicSelectionHit = [point.x, point.y, nearestHit.x, nearestHit.y];
       const contourIndex = nearestHit.contourIndex;
       this.selectContour(sceneController, contourIndex, getMagicSelectModeFunction);
+    } else {
+      sceneController.magicSelectionHit = undefined;
     }
   }
 

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -349,10 +349,14 @@ export class PointerTool extends BaseTool {
 
   async handleMagicSelect(eventStream, sceneController) {
     const glyphController = await this.sceneModel.getSelectedStaticGlyphController();
-    for await (const event of eventStream) {      
-      const nearestHit = this.getNearestHit(sceneController, event, glyphController);
-      const contourIndex = nearestHit.contourIndex;
-      this.selectContour(sceneController, contourIndex, getMagicSelectModeFunction);
+    for await (const event of eventStream) {   
+      if (event.metaKey) {   
+        const nearestHit = this.getNearestHit(sceneController, event, glyphController);
+        const contourIndex = nearestHit.contourIndex;
+        this.selectContour(sceneController, contourIndex, getMagicSelectModeFunction);
+      } else {
+        sceneController.magicSelectionHit = undefined;
+      }
     }
   }
 

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -188,13 +188,13 @@ export class PointerTool extends BaseTool {
       eventStream.done();
       return;
     }
+
     let initiateDrag = false;
     let initiateRectSelect = false;
 
     const modeFunc = getSelectModeFunction(event);
     const newSelection = modeFunc(sceneController.selection, selection);
     const cleanSel = selection;
-
     if (
       !selection.size ||
       event.shiftKey ||
@@ -204,6 +204,7 @@ export class PointerTool extends BaseTool {
       this._selectionBeforeSingleClick = sceneController.selection;
       sceneController.selection = newSelection;
     }
+    
     if (isSuperset(sceneController.selection, cleanSel)) {
       initiateDrag = true;
     }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -240,7 +240,7 @@ export class PointerTool extends BaseTool {
       }
     }
 
-    if (initialEvent.metaKey) {
+    if (initialEvent.metaKey && initiateRectSelect) {
       const glyphController = await this.sceneModel.getSelectedStaticGlyphController();
       this.getNearestHit(sceneController, initialEvent, glyphController);
       if (initiateRectSelect) {

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -138,12 +138,12 @@ export class PointerTool extends BaseTool {
     point.y -= positionedGlyph.y;
     const pathHitTester = glyphController.pathHitTester;
     const nearestHit = pathHitTester.findNearest(point);
-    if (nearestHit){
+    if (nearestHit) {
       sceneController.magicSelectionHit = [
         point.x,
         point.y,
         nearestHit.x,
-        nearestHit.y
+        nearestHit.y,
       ];
       const contourIndex = nearestHit.contourIndex;
       this.selectContour(sceneController, contourIndex, getMagicSelectModeFunction);

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -58,6 +58,7 @@ export class PointerTool extends BaseTool {
     sceneController.hoverSelection = selection;
     sceneController.hoveredGlyph = undefined;
     sceneController.hoverPathHit = pathHit;
+    sceneController.sceneModel.magicSelection = [];
 
     if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
       sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
@@ -125,6 +126,7 @@ export class PointerTool extends BaseTool {
       }
     }
     const selection = this._selectionBeforeSingleClick || sceneController.selection;
+    sceneController.selection = undefined;
     this._selectionBeforeSingleClick = undefined;
     const modeFunc = selectModeFunction(event);
     sceneController.selection = modeFunc(selection, newSelection);
@@ -137,6 +139,7 @@ export class PointerTool extends BaseTool {
     point.y -= positionedGlyph.y;
     const pathHitTester = glyphController.flattenedPathHitTester;
     const nearestHit = pathHitTester.findNearest(point);
+    sceneController.sceneModel.magicSelection = [point.x, point.y, nearestHit.x, nearestHit.y];
     return nearestHit;
   }
 

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -139,7 +139,12 @@ export class PointerTool extends BaseTool {
     const pathHitTester = glyphController.pathHitTester;
     const nearestHit = pathHitTester.findNearest(point);
     if (nearestHit){
-      sceneController.magicSelectionHit = [point.x, point.y, nearestHit.x, nearestHit.y];
+      sceneController.magicSelectionHit = [
+        point.x, 
+        point.y, 
+        nearestHit.x, 
+        nearestHit.y
+      ];
       const contourIndex = nearestHit.contourIndex;
       this.selectContour(sceneController, contourIndex, getMagicSelectModeFunction);
     } else {
@@ -238,7 +243,7 @@ export class PointerTool extends BaseTool {
     if (initialEvent.metaKey) {
       const glyphController = await this.sceneModel.getSelectedStaticGlyphController();
       this.getNearestHit(sceneController, initialEvent, glyphController);
-      if (initiateRectSelect){
+      if (initiateRectSelect) {
         return await this.handleMagicSelect(eventStream, sceneController);
       }
     } else {
@@ -351,7 +356,7 @@ export class PointerTool extends BaseTool {
 
   async handleMagicSelect(eventStream, sceneController) {
     const glyphController = await this.sceneModel.getSelectedStaticGlyphController();
-    for await (const event of eventStream) {   
+    for await (const event of eventStream) {
       if (event.metaKey) {   
         this.getNearestHit(sceneController, event, glyphController);
       } else {

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -58,7 +58,7 @@ export class PointerTool extends BaseTool {
     sceneController.hoverSelection = selection;
     sceneController.hoveredGlyph = undefined;
     sceneController.hoverPathHit = pathHit;
-    sceneController.magicSelectionHit = [];
+    sceneController.magicSelectionHit = undefined;
 
     if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
       sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -358,6 +358,7 @@ export class PointerTool extends BaseTool {
         sceneController.magicSelectionHit = undefined;
       }
     }
+    sceneController.magicSelectionHit = undefined;
   }
 
   async handleDragSelection(eventStream, initialEvent) {

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -240,7 +240,7 @@ export class PointerTool extends BaseTool {
       }
     }
 
-    if (initialEvent.metaKey && initiateRectSelect) {
+    if (initialEvent.metaKey && !initialClickedPointIndex) {
       const glyphController = await this.sceneModel.getSelectedStaticGlyphController();
       this.getNearestHit(sceneController, initialEvent, glyphController);
       if (initiateRectSelect) {

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -58,7 +58,7 @@ export class PointerTool extends BaseTool {
     sceneController.hoverSelection = selection;
     sceneController.hoveredGlyph = undefined;
     sceneController.hoverPathHit = pathHit;
-    sceneController.sceneModel.magicSelection = [];
+    sceneController.magicSelection = [];
 
     if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
       sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
@@ -126,7 +126,6 @@ export class PointerTool extends BaseTool {
       }
     }
     const selection = this._selectionBeforeSingleClick || sceneController.selection;
-    sceneController.selection = undefined;
     this._selectionBeforeSingleClick = undefined;
     const modeFunc = selectModeFunction(event);
     sceneController.selection = modeFunc(selection, newSelection);
@@ -139,7 +138,7 @@ export class PointerTool extends BaseTool {
     point.y -= positionedGlyph.y;
     const pathHitTester = glyphController.flattenedPathHitTester;
     const nearestHit = pathHitTester.findNearest(point);
-    sceneController.sceneModel.magicSelection = [point.x, point.y, nearestHit.x, nearestHit.y];
+    sceneController.magicSelection = [point.x, point.y, nearestHit.x, nearestHit.y];
     return nearestHit;
   }
 

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -140,9 +140,9 @@ export class PointerTool extends BaseTool {
     const nearestHit = pathHitTester.findNearest(point);
     if (nearestHit){
       sceneController.magicSelectionHit = [
-        point.x, 
-        point.y, 
-        nearestHit.x, 
+        point.x,
+        point.y,
+        nearestHit.x,
         nearestHit.y
       ];
       const contourIndex = nearestHit.contourIndex;
@@ -357,7 +357,7 @@ export class PointerTool extends BaseTool {
   async handleMagicSelect(eventStream, sceneController) {
     const glyphController = await this.sceneModel.getSelectedStaticGlyphController();
     for await (const event of eventStream) {
-      if (event.metaKey) {   
+      if (event.metaKey) {
         this.getNearestHit(sceneController, event, glyphController);
       } else {
         sceneController.magicSelectionHit = undefined;

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -831,6 +831,15 @@ export class SceneController {
     this.canvasController.requestUpdate();
   }
 
+  get magicSelection() {
+    return this.sceneModel.magicSelection;
+  }
+
+  set magicSelection(magicSel) {
+    this.sceneModel.magicSelection = magicSel;
+    this.canvasController.requestUpdate();
+  }
+
   get backgroundLayers() {
     return this.sceneModel.backgroundLayers || [];
   }

--- a/src/fontra/views/editor/scene-controller.js
+++ b/src/fontra/views/editor/scene-controller.js
@@ -831,12 +831,12 @@ export class SceneController {
     this.canvasController.requestUpdate();
   }
 
-  get magicSelection() {
-    return this.sceneModel.magicSelection;
+  get magicSelectionHit() {
+    return this.sceneModel.magicSelectionHit;
   }
 
-  set magicSelection(magicSel) {
-    this.sceneModel.magicSelection = magicSel;
+  set magicSelectionHit(magicSelHit) {
+    this.sceneModel.magicSelectionHit = magicSelHit;
     this.canvasController.requestUpdate();
   }
 

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -1546,6 +1546,29 @@ registerVisualizationLayerDefinition({
 });
 
 registerVisualizationLayerDefinition({
+  identifier: "fontra.magic.select",
+  name: "Magic select",
+  selectionMode: "editing",
+  zIndex: 500,
+  screenParameters: {
+    strokeWidth: 1,
+    lineDash: [10, 10],
+  },
+  draw: (context, positionedGlyph, parameters, model, controller) => {
+    if (model.magicSelection === undefined) {
+      return;
+    }
+    const selRect = model.magicSelection;
+    const x = selRect[0];
+    const y = selRect[1];
+    const w = selRect[2];
+    const h = selRect[3];
+    context.lineWidth = parameters.strokeWidth;
+    strokeLineDashed(context, x, y, w, h);
+  },
+});
+
+registerVisualizationLayerDefinition({
   identifier: "fontra.rect.select",
   name: "Rect select",
   selectionMode: "editing",

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -1559,12 +1559,12 @@ registerVisualizationLayerDefinition({
       return;
     }
     const selRect = model.magicSelection;
-    const x = selRect[0];
-    const y = selRect[1];
-    const w = selRect[2];
-    const h = selRect[3];
+    const p1x = selRect[0];
+    const p1y = selRect[1];
+    const p2x = selRect[2];
+    const p2y = selRect[3];
     context.lineWidth = parameters.strokeWidth;
-    strokeLineDashed(context, x, y, w, h);
+    strokeLineDashed(context, p1x, p1y, p2x, p2y);
   },
 });
 

--- a/src/fontra/views/editor/visualization-layer-definitions.js
+++ b/src/fontra/views/editor/visualization-layer-definitions.js
@@ -1555,14 +1555,14 @@ registerVisualizationLayerDefinition({
     lineDash: [10, 10],
   },
   draw: (context, positionedGlyph, parameters, model, controller) => {
-    if (model.magicSelection === undefined) {
+    if (model.magicSelectionHit === undefined) {
       return;
     }
-    const selRect = model.magicSelection;
-    const p1x = selRect[0];
-    const p1y = selRect[1];
-    const p2x = selRect[2];
-    const p2y = selRect[3];
+    const magicSelHit = model.magicSelectionHit;
+    const p1x = magicSelHit[0];
+    const p1y = magicSelHit[1];
+    const p2x = magicSelHit[2];
+    const p2y = magicSelHit[3];
     context.lineWidth = parameters.strokeWidth;
     strokeLineDashed(context, p1x, p1y, p2x, p2y);
   },


### PR DESCRIPTION
A pull request for magic contour selection with the pointer tool.

By holding the cmd (metaKey) modifier key:

- Clicking anywhere in the glyph editor view selects the nearest contour.
- Holding shift and clicking somewhere else adds the nearest contour to the selection.
- Dragging the mouse changes the selection to the nearest contour.
- Dragging while holding shift adds the nearest contours to the selection.

Note:
In `path-hit-tester.js` -> `PathHitTester` -> `findNearest`, I commented out line 65:
`results = results.filter((hit) => hit.t != 0 && hit.t != 1);`

This line restricts findNearest to only work when, in the case of a rectangular shape, the cursor's x value is between the rectangle's xmin and xmax, or the y value is between its ymin and ymax. 
This function is used exclusively with the power ruler tool and now the pointer tool. Commenting out this line seems to have no effect on the power ruler tool.