### PR TITLE
Don’t set context.direction to undefined

### DIFF
--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -160,7 +160,7 @@ registerVisualizationLayerDefinition({
     );
     if (glyphString) {
       context.font = `${placeholderFontSize}px fontra-ui-regular, sans-serif`;
-      context.direction = direction;
+      context.direction = direction || context.direction;
       context.fillText(
         glyphString,
         positionedGlyph.glyph.xAdvance / 2,


### PR DESCRIPTION
If `guessGlyphPlaceholderString()` returns `undefined` for direction, keep `context.direction` unchanged.

Fixes https://github.com/googlefonts/fontra/issues/2171