### PR TITLE
Make sure we exit 'clean view' in edge case

### DIFF
--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3133,7 +3133,15 @@ export class EditorController extends ViewController {
   }
 
   keyUpHandler(event) {
-    if (this._matchingKeyUpHandler && this._matchingKeyUpHandler.code == event.code) {
+    if (
+      this._matchingKeyUpHandler &&
+      // At least on macOS, in Chrome and Safari, if _while the space key is
+      // pressed_ we additionally press the command key ("Meta"), we will never
+      // receive a keyup event for the space key. So let's also respond to any
+      // keyup for the Meta key.
+      // Oddly, event.metaKey is false at keyup, so we check event.key instead.
+      (this._matchingKeyUpHandler.code == event.code || event.key == "Meta")
+    ) {
       this._matchingKeyUpHandler.callback(event);
       delete this._matchingKeyUpHandler;
     }


### PR DESCRIPTION
Case:

- press and hold space (enter clean view)
- press and hold command key
- release space key and command key (in any order)

We never receive a keyup event for the space key, so this leaves us in clean view, and with the hand tool selected.

This PR makes sure we also exit clean view in that case by listening to the keyup for the command key.