### PR TITLE
Keep clean view active by removing keyup for meta key

### DIFF
--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3148,7 +3148,7 @@ export class EditorController extends ViewController {
       // receive a keyup event for the space key. So let's also respond to any
       // keyup for the Meta key.
       // Oddly, event.metaKey is false at keyup, so we check event.key instead.
-      (this._matchingKeyUpHandler.code == event.code)
+      this._matchingKeyUpHandler.code == event.code
     ) {
       this._matchingKeyUpHandler.callback(event);
       delete this._matchingKeyUpHandler;

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3148,7 +3148,7 @@ export class EditorController extends ViewController {
       // receive a keyup event for the space key. So let's also respond to any
       // keyup for the Meta key.
       // Oddly, event.metaKey is false at keyup, so we check event.key instead.
-      (this._matchingKeyUpHandler.code == event.code || event.key == "Meta")
+      (this._matchingKeyUpHandler.code == event.code)
     ) {
       this._matchingKeyUpHandler.callback(event);
       delete this._matchingKeyUpHandler;


### PR DESCRIPTION
This is a feature I used a lot, and I really miss it now. It allowed me to keep a clean view by pressing the Cmd modifier before releasing my clean-view shortcut key. This gave me a global clean overview without having to keep a key pressed, allowed me to navigate the canvas without holding the clean-view key, and also let me continue editing glyph shapes while staying in clean-view mode. I’d love to revert this change and get back the ability to lock the clean view.