### PR TITLE
Glyph editor: improve node visibility

### DIFF
--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -1679,12 +1679,23 @@ export const allGlyphsCleanVisualizationLayerDefinition = {
 
 function fillNode(context, pt, cornerNodeSize, smoothNodeSize, handleNodeSize) {
   if (!pt.type && !pt.smooth) {
-    fillSquareNode(context, pt, cornerNodeSize);
+    fillDiamondNode(context, pt, cornerNodeSize);
   } else if (!pt.type) {
-    fillRoundNode(context, pt, smoothNodeSize);
+    fillSquareNode(context, pt, smoothNodeSize);
   } else {
     fillRoundNode(context, pt, handleNodeSize);
   }
+}
+
+function fillDiamondNode(context, pt, nodeSize) {
+  const offset = nodeSize / 1.4;
+  context.beginPath();
+  context.moveTo(pt.x, pt.y - offset);
+  context.lineTo(pt.x + offset, pt.y);
+  context.lineTo(pt.x, pt.y + offset);
+  context.lineTo(pt.x - offset, pt.y);
+  context.closePath();
+  context.fill();
 }
 
 function fillSquareNode(context, pt, nodeSize) {


### PR DESCRIPTION
When tracing glyphs by setting the background to, for example, scans of old specimen books, the colourise feature is already extremely helpful to help distinguish the sample from the glyph and its outline. However, I often have trouble spotting the gray nodes and handles, making editing a more vexing experience than necessary.

In this branch I am experimenting with making the nodes more visible. I am taking inspiration from Inkscape, but the approach used seems conventional for vector editing tools in general.

I don't expect this PR to be ready for merging without more experimenting and feedback, but I figured it would provide a good starting point for the issues this addresses. Please have a look.

## Changes introduced

A double border of alternating black and white is added to each node. With this it no longer matters what colour the background has, because if it matches one border (rendering it nearly invisible) it will be contrasted by the other.

This is the current rendering:

<img width="702" height="525" alt="Screenshot from 2026-01-27 10-48-03" src="https://github.com/user-attachments/assets/12d5743f-2c81-4869-b67f-6843ebe8cce2" />

This is the rendering on this branch:

<img width="703" height="458" alt="Screenshot from 2026-01-27 11-12-58" src="https://github.com/user-attachments/assets/fab61390-9246-48da-ad78-898211e950e2" />

The second commit changes the shape of the nodes to further distinguish handles from nodes. The handles remain round, but the smooth nodes are now square and the angled nodes diamond shaped. This follows the convention used by Inkscape, which seems natural to me, but another approach could work. My primary goal here is to remove the ambiguity between smooth nodes and handles.

## Questions

* The nodes render below the glyph outline. This is more visible in this branch than on `main`, but the same thing happens there. Is this intentional?

## Related issues

* Possibly related to #1864.