### PR TITLE
[fontoverview] Make alt/option key do the same as meta/command/Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Fontra
 
+## 2026-04-?? [version 2026.4.1]
+
+### Fixes
+
+- [font overview] Accept the alt/option key as a modifier to toggle the glyph selection (when clicking or dragging). This can already be done with the command/Windows/meta key, but that has an annoying side effect on Windows. [Issue 2536](https://github.com/fontra/fontra/issues/2536), [PR 2537](https://github.com/fontra/fontra/pull/2537)
+
 ## 2026-04-01 [version 2026.4.0]
 
 ### New features

--- a/src-js/fontra-webcomponents/src/glyph-cell-view.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell-view.js
@@ -392,7 +392,7 @@ export class GlyphCellView extends HTMLElement {
     const glyphName = glyphCell.glyphName;
 
     if (this.glyphSelection.has(glyphName)) {
-      if (event.metaKey) {
+      if (event.metaKey || event.altKey) {
         this._resetSelectionHelpers();
         this.glyphSelection = difference(this.glyphSelection, [glyphName]);
       } else if (resetGlyphSelection && this.glyphSelection.size > 1) {
@@ -408,7 +408,7 @@ export class GlyphCellView extends HTMLElement {
         }, 500);
       }
     } else {
-      if (event.metaKey) {
+      if (event.metaKey || event.altKey) {
         this.glyphSelection = union(this.glyphSelection, [glyphName]);
       } else {
         this.glyphSelection = new Set([glyphName]);
@@ -477,7 +477,7 @@ export class GlyphCellView extends HTMLElement {
     }
 
     this._clickedCell = glyphCell;
-    this._dragErase = event.metaKey ? glyphCell.selected : false;
+    this._dragErase = event.metaKey || event.altKey ? glyphCell.selected : false;
     this._mouseInCell = true;
     this._mouseDownSelection = this.glyphSelection;
   }
@@ -593,7 +593,7 @@ export class GlyphCellView extends HTMLElement {
       this.extendSelection(glyphCell);
     } else {
       let selection = this.getGlyphNamesForRange(this._firstClickedCell, glyphCell);
-      if (this._mouseDownEvent.metaKey) {
+      if (this._mouseDownEvent.metaKey || this._mouseDownEvent.altKey) {
         selection = this._dragErase
           ? difference(this.glyphSelection, selection)
           : union(this._mouseDownSelection, selection);


### PR DESCRIPTION
That is: toggle the glyph selection when clicking or dragging in the glyph cell view.

This fixes #2536.