### PR TITLE
[pointer tool] Convert a line to a curve with alt-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-?? [version 2026.4.1]
 
+### New features
+
+- [pointer tool] Convert a line to a curve with alt-click (avoiding the need to switch to the pen tool for this) [PR 2538](https://github.com/fontra/fontra/pull/2538)
+
 ### Fixes
 
 - [font overview] Accept the alt/option key as a modifier to toggle the glyph selection (when clicking or dragging). This can already be done with the command/Windows/meta key, but that has an annoying side effect on Windows. [Issue 2536](https://github.com/fontra/fontra/issues/2536), [PR 2537](https://github.com/fontra/fontra/pull/2537)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- [pointer tool] Convert a line to a curve with alt-click (avoiding the need to switch to the pen tool for this) [PR 2538](https://github.com/fontra/fontra/pull/2538)
+- [pointer tool] Convert a line to a curve with alt-click (eliminating the need to switch to the pen tool for this) [PR 2538](https://github.com/fontra/fontra/pull/2538)
 
 ### Fixes
 

--- a/src-js/views-editor/src/edit-tools-pen.js
+++ b/src-js/views-editor/src/edit-tools-pen.js
@@ -156,7 +156,7 @@ export class PenToolCubic extends BaseTool {
     if (this.sceneModel.pathConnectTargetPoint?.segment) {
       await this._handleInsertPoint();
     } else if (this.sceneModel.pathInsertHandles) {
-      await this._handleInsertHandles();
+      await this.handleInsertHandles();
     } else {
       this._resetHover();
       await this._handleAddPoints(eventStream, initialEvent);
@@ -179,7 +179,7 @@ export class PenToolCubic extends BaseTool {
     });
   }
 
-  async _handleInsertHandles() {
+  async handleInsertHandles() {
     const segmentPointIndices =
       this.sceneModel.pathInsertHandles.hit.segment.pointIndices;
     await this.sceneController.editLayersAndRecordChanges((layerGlyphs) => {

--- a/src-js/views-editor/src/edit-tools-pen.js
+++ b/src-js/views-editor/src/edit-tools-pen.js
@@ -100,11 +100,7 @@ export class PenToolCubic extends BaseTool {
       const size = Math.max(1, this.sceneController.mouseClickMargin);
       const hit = this.sceneModel.pathHitAtPoint(point, size);
       if (event.altKey && hit.segment?.points?.length === 2) {
-        const pt1 = hit.segment.points[0];
-        const pt2 = hit.segment.points[1];
-        const handle1 = vector.roundVector(vector.interpolateVectors(pt1, pt2, 1 / 3));
-        const handle2 = vector.roundVector(vector.interpolateVectors(pt1, pt2, 2 / 3));
-        return { insertHandles: { points: [handle1, handle2], hit: hit } };
+        return this.getInsertHandlesFromPathHit(hit);
       } else {
         const targetPoint = { ...hit };
         if ("x" in targetPoint) {
@@ -145,6 +141,14 @@ export class PenToolCubic extends BaseTool {
       return {};
     }
     return { targetPoint: path.getPoint(hoveredPointIndex) };
+  }
+
+  getInsertHandlesFromPathHit(hit) {
+    const pt1 = hit.segment.points[0];
+    const pt2 = hit.segment.points[1];
+    const handle1 = vector.roundVector(vector.interpolateVectors(pt1, pt2, 1 / 3));
+    const handle2 = vector.roundVector(vector.interpolateVectors(pt1, pt2, 2 / 3));
+    return { insertHandles: { points: [handle1, handle2], hit: hit } };
   }
 
   async handleDrag(eventStream, initialEvent) {

--- a/src-js/views-editor/src/edit-tools-pen.js
+++ b/src-js/views-editor/src/edit-tools-pen.js
@@ -718,7 +718,7 @@ function getHoveredPointIndex(sceneController, event) {
   return pointSelection[0];
 }
 
-function handlesEqual(handles1, handles2) {
+export function handlesEqual(handles1, handles2) {
   const points1 = handles1?.points;
   const points2 = handles2?.points;
   return (

--- a/src-js/views-editor/src/edit-tools-pointer.js
+++ b/src-js/views-editor/src/edit-tools-pointer.js
@@ -33,6 +33,7 @@ import { VarPackedPath } from "@fontra/core/var-path.js";
 import * as vector from "@fontra/core/vector.js";
 import { EditBehaviorFactory } from "./edit-behavior.js";
 import { BaseTool, shouldInitiateDrag } from "./edit-tools-base.js";
+import { handlesEqual } from "./edit-tools-pen.js";
 import { getPinPoint } from "./panel-transformation.js";
 import { equalGlyphSelection } from "./scene-controller.js";
 import {
@@ -67,16 +68,37 @@ export class PointerTool extends BaseTool {
       sceneController.hoverSelection,
       event.altKey
     );
-    sceneController.hoverSelection = selection;
-    sceneController.hoverPathHit = pathHit;
+
+    this.sceneController.sceneModel.showTransformSelection = true;
+
+    let insertHandles = null;
+
+    if (
+      this.sceneModel.canEdit &&
+      event.altKey &&
+      pathHit?.segment.points.length == 2
+    ) {
+      ({ insertHandles } = this.editor
+        .getPenTool()
+        .getInsertHandlesFromPathHit(pathHit));
+
+      sceneController.hoverSelection = new Set();
+      sceneController.hoverPathHit = undefined;
+    } else {
+      sceneController.hoverSelection = selection;
+      sceneController.hoverPathHit = pathHit;
+    }
+
+    if (!handlesEqual(insertHandles, this.sceneModel.pathInsertHandles)) {
+      this.sceneModel.pathInsertHandles = insertHandles;
+      this.canvasController.requestUpdate();
+    }
 
     if (!sceneController.hoverSelection.size && !sceneController.hoverPathHit) {
       sceneController.hoveredGlyph = this.sceneModel.glyphAtPoint(point);
     } else {
       sceneController.hoveredGlyph = undefined;
     }
-
-    this.sceneController.sceneModel.showTransformSelection = true;
 
     const resizeHandle = this.getResizeHandle(event, sceneController.selection);
     const rotationHandle = !resizeHandle
@@ -127,6 +149,11 @@ export class PointerTool extends BaseTool {
   }
 
   async handleDrag(eventStream, initialEvent) {
+    if (this.sceneModel.pathInsertHandles) {
+      await this.editor.getPenTool().handleInsertHandles();
+      return;
+    }
+
     const sceneController = this.sceneController;
     const initialSelection = sceneController.selection;
     const resizeHandle = this.getResizeHandle(initialEvent, initialSelection);

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -1207,6 +1207,10 @@ export class EditorController extends ViewController {
     this.selectedToolIdentifier = selectedToolIdentifier;
   }
 
+  getPenTool() {
+    return this.tools[this.getToolIdentifierFromMultiTool("pen-tool")];
+  }
+
   getToolIdentifierFromMultiTool(toolIdentifier) {
     for (const editToolItem of document.querySelectorAll(
       "#edit-tools > .tool-button"

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -1207,6 +1207,21 @@ export class EditorController extends ViewController {
     this.selectedToolIdentifier = selectedToolIdentifier;
   }
 
+  getToolIdentifierFromMultiTool(toolIdentifier) {
+    for (const editToolItem of document.querySelectorAll(
+      "#edit-tools > .tool-button"
+    )) {
+      if (
+        editToolItem.classList.contains("multi-tool") &&
+        editToolItem.dataset.tool === toolIdentifier
+      ) {
+        return editToolItem.children[0].dataset.tool;
+      }
+    }
+
+    return toolIdentifier;
+  }
+
   themeChanged() {
     this.visualizationLayers.darkTheme = this.isThemeDark;
     this.cleanGlyphsLayers.darkTheme = this.isThemeDark;

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -590,6 +590,11 @@ export class SceneModel {
     return mapObjectKeys(shaperLocation, (key) => nameToTagMapping[key]);
   }
 
+  get canEdit() {
+    const glyphController = this.getSelectedPositionedGlyph()?.glyph;
+    return !!glyphController?.canEdit;
+  }
+
   getLocationForGlyph(glyphName) {
     return {
       ...this.sceneSettings.fontLocationSourceMapped,


### PR DESCRIPTION
By popular request: Make alt-click on a straight line with the pointer tool convert it to a curve

Previously this had to be done with the pen tool — this PR additionally makes this possible with the pointer tool.

It takes the curve type of the pen tool into account.