### PR TITLE
Security: Untrusted SVG content inserted into DOM without sanitization

### DIFF
--- a/src-js/fontra-webcomponents/src/inline-svg.js
+++ b/src-js/fontra-webcomponents/src/inline-svg.js
@@ -33,22 +33,66 @@ export class InlineSVG extends HTMLElement {
   }
 
   async fetchSVG(svgSRC) {
-    const svgElement = htmlToElement(await cachedSVGData(svgSRC));
-    svgElement.removeAttribute("width");
-    svgElement.removeAttribute("height");
-    this.innerHTML = "";
-    this.appendChild(svgElement);
+    try {
+      const svgElement = htmlToElement(sanitizeSVG(await cachedSVGData(svgSRC)));
+      svgElement.removeAttribute("width");
+      svgElement.removeAttribute("height");
+      this.innerHTML = "";
+      this.appendChild(svgElement);
+    } catch (error) {
+      this.innerHTML = "";
+      throw error;
+    }
   }
+}
+
+function sanitizeSVG(svgData) {
+  const doc = new DOMParser().parseFromString(svgData, "image/svg+xml");
+  const svgElement = doc.documentElement;
+  if (svgElement?.tagName?.toLowerCase() !== "svg") {
+    throw new Error("Invalid SVG");
+  }
+
+  svgElement.querySelectorAll("script, foreignObject").forEach((el) => el.remove());
+
+  for (const el of svgElement.querySelectorAll("*")) {
+    for (const attr of [...el.attributes]) {
+      const name = attr.name.toLowerCase();
+      const value = attr.value.trim();
+      if (name.startsWith("on")) {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+      if (
+        (name === "href" || name === "xlink:href") &&
+        value &&
+        !value.startsWith("#")
+      ) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  return svgElement.outerHTML;
 }
 
 const svgDataCache = new Map();
 
 async function cachedSVGData(svgSRC) {
-  let svgData = svgDataCache.get(svgSRC);
+  const srcURL = new URL(svgSRC, window.location.href);
+  if (srcURL.origin !== window.location.origin) {
+    throw new Error("Cross-origin SVG sources are not allowed");
+  }
+
+  const cacheKey = srcURL.href;
+  let svgData = svgDataCache.get(cacheKey);
   if (!svgData) {
-    const response = await fetch(svgSRC);
+    const response = await fetch(cacheKey);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch SVG: ${response.status}`);
+    }
     svgData = await response.text();
-    svgDataCache.set(svgSRC, svgData);
+    svgDataCache.set(cacheKey, svgData);
   }
   return svgData;
 }


### PR DESCRIPTION
## Problem

`InlineSVG` fetches SVG text and converts/inserts it into the DOM. If `src` is attacker-controlled or can be redirected to untrusted content, malicious SVG payloads (event handlers, scriptable elements, external references) may lead to XSS or data exfiltration.

**Severity**: `high`
**File**: `src-js/fontra-webcomponents/src/inline-svg.js`

## Solution

Restrict SVG sources to trusted same-origin paths, enforce a strict CSP, and sanitize SVG before DOM insertion (remove scripts, event attributes, `foreignObject`, external hrefs). Prefer rendering via safe `<img>` when interactivity is not needed.

## Changes

- `src-js/fontra-webcomponents/src/inline-svg.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
