### PR TITLE
[conditional substitutions] Drop substitutions that use unknown glyphs

### DIFF
--- a/src-js/fontra-core/src/shaper-controller.js
+++ b/src-js/fontra-core/src/shaper-controller.js
@@ -3,7 +3,7 @@ import { collectGlyphNames } from "./changes.js";
 import { getGlyphInfoFromCodePoint, getGlyphInfoFromGlyphName } from "./glyph-data.js";
 import { ObservableController } from "./observable-object.js";
 import { getShaper } from "./shaper.js";
-import { consolidateCalls, scheduleCalls } from "./utils.js";
+import { consolidateCalls, filterObject, scheduleCalls } from "./utils.js";
 import { piecewiseLinearMap } from "./var-model.js";
 
 export class ShaperController {
@@ -169,7 +169,8 @@ export class ShaperController {
     const features = await this.fontController.getFeatures();
     const conditionalSubstitutions = prepareConditionalSubstitutions(
       await this.fontController.getConditionalSubstitutions(),
-      this.fontController.fontAxes
+      this.fontController.fontAxes,
+      this.fontController.glyphMap
     );
 
     const glyphClasses = await this.getGlyphClasses();
@@ -317,7 +318,7 @@ function ensureNotdef(glyphOrder) {
   glyphOrder.unshift(".notdef");
 }
 
-function prepareConditionalSubstitutions(substitutions, fontAxes) {
+function prepareConditionalSubstitutions(substitutions, fontAxes, glyphMap) {
   const axesByName = Object.fromEntries(fontAxes.map((axis) => [axis.name, axis]));
   const mapFuncs = Object.fromEntries(
     fontAxes.map((axis) => {
@@ -345,7 +346,10 @@ function prepareConditionalSubstitutions(substitutions, fontAxes) {
           })
         )
       ),
-      substitutions,
+      filterObject(
+        substitutions,
+        (glyph1, glyph2) => glyph1 in glyphMap && glyph2 in glyphMap
+      ),
     ]),
   };
 }


### PR DESCRIPTION
This avoids an error when building the shaper font. The UI for creating the conditional substitutions will be responsible for ensuring all referenced glyphs exist, or report to the user if this isn't the case.