### PR TITLE
[shaping debugger] Create and read "Debg" table, link to feature source code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,9 +2394,9 @@
       "license": "MIT"
     },
     "node_modules/build-shaper-font": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/build-shaper-font/-/build-shaper-font-0.1.6.tgz",
-      "integrity": "sha512-2rfp/wvp4RNAkmCu3FqcvTjCTLHhm2Bmkqb/hgtfye1RvjcvWth+HngfT32ImnMfjKC4zIsRclYcW2ldlGfr8Q==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/build-shaper-font/-/build-shaper-font-0.1.7.tgz",
+      "integrity": "sha512-YNEs7KisQgX1MBgJIVxrJ/llbYisuApqO8G5BjQB/sG1DRtOwkyiRohTxYW2KGdXjd1ukNxshRPJs0n6EFKN5A==",
       "license": "Apache-2.0"
     },
     "node_modules/camel-case": {
@@ -6780,7 +6780,7 @@
       "dependencies": {
         "@fontra/core": "file:",
         "bezier-js": "^6.1.4",
-        "build-shaper-font": "^0.1.6",
+        "build-shaper-font": "^0.1.7",
         "fflate": "^0.8.2",
         "harfbuzzjs": "^0.10.3",
         "lib-font": "^3.0.0",

--- a/src-js/fontra-core/package.json
+++ b/src-js/fontra-core/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@fontra/core": "file:",
     "bezier-js": "^6.1.4",
-    "build-shaper-font": "^0.1.6",
+    "build-shaper-font": "^0.1.7",
     "fflate": "^0.8.2",
     "harfbuzzjs": "^0.10.3",
     "lib-font": "^3.0.0",

--- a/src-js/fontra-core/src/shaper-controller.js
+++ b/src-js/fontra-core/src/shaper-controller.js
@@ -188,6 +188,7 @@ export class ShaperController {
           })),
         glyphClasses,
         conditionalSubstitutions: [conditionalSubstitutions],
+        compileDebg: true,
       });
     } catch (e) {
       console.error(e);

--- a/src-js/fontra-core/src/shaper.js
+++ b/src-js/fontra-core/src/shaper.js
@@ -282,13 +282,16 @@ class HBShaper extends ShaperBase {
     let glyphsFollowWritingDirection = true;
 
     const messageFunc = (buffer, font, message) => {
+      const match =
+        gposPhase || messages ? message.match(/(^start )?lookup (\d+)/) : null;
+      const lookupId = match ? parseInt(match[2]) : undefined;
+
       if (gposPhase) {
-        const match = message.match(/^start lookup (\d+)/);
-        if (match || message.startsWith("end table GPOS")) {
+        if (match?.[1] || message.startsWith("end table GPOS")) {
           let glyphs;
           const glyphObjects = this._glyphObjects;
           let didModify = false;
-          const beforeLookupId = match ? parseInt(match[1]) : undefined;
+          const beforeLookupId = lookupId;
 
           for (const { tag, lookupId } of this.insertMarkers ?? []) {
             if (
@@ -344,11 +347,19 @@ class HBShaper extends ShaperBase {
 
         const glyphsSerialized = JSON.stringify(glyphs);
 
+        const debugInfo = this.debugInfo;
+        const sourceLocation = debugInfo
+          ? debugInfo["com.github.fonttools.feaLib"]?.[gposPhase ? "GPOS" : "GSUB"]?.[
+              lookupId
+            ]?.[0]
+          : undefined;
+
         messages.push({
           message,
           changed:
             this._previousGlyphsSerialized &&
             glyphsSerialized != this._previousGlyphsSerialized,
+          sourceLocation,
         });
 
         this._previousGlyphsSerialized = glyphsSerialized;
@@ -443,6 +454,17 @@ class HBShaper extends ShaperBase {
     }
 
     return result;
+  }
+
+  get debugInfo() {
+    if (this._debugInfo === undefined) {
+      const debgTable = this.face.reference_table("Debg");
+      this._debugInfo = debgTable
+        ? JSON.parse(new TextDecoder().decode(debgTable))
+        : null;
+    }
+
+    return this._debugInfo;
   }
 
   close() {

--- a/src-js/fontra-core/src/shaper.js
+++ b/src-js/fontra-core/src/shaper.js
@@ -348,10 +348,15 @@ class HBShaper extends ShaperBase {
         const glyphsSerialized = JSON.stringify(glyphs);
 
         const debugInfo = this.debugInfo;
-        const sourceLocation = debugInfo
+        const sourceInfo = debugInfo
           ? debugInfo["com.github.fonttools.feaLib"]?.[gposPhase ? "GPOS" : "GSUB"]?.[
               lookupId
-            ]?.[0]
+            ]
+          : undefined;
+        const sourceLocation = sourceInfo?.[1]
+          ? `${sourceInfo[0]} (${sourceInfo[1]})`
+          : sourceInfo
+          ? `${sourceInfo[0]}`
           : undefined;
 
         messages.push({

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -240,11 +240,14 @@ export default class CharactersGlyphsPanel extends Panel {
         key: "sourceLocation",
         title: "Feature source",
         get: (item) => {
-          const match = item.sourceLocation?.match(/^<features>:(\d+):(\d+)/);
+          const match = item.sourceLocation?.match(
+            /^<features>:(?<lineno>\d+):(?<column>\d+)/
+          );
           if (match) {
             const opentypeFeaturesURL = new URL(window.location);
             opentypeFeaturesURL.pathname = "fontinfo.html";
-            opentypeFeaturesURL.hash = `#opentype-feature-code-panel#L${match[1]}:${match[2]}`;
+            const { lineno, column } = match.groups;
+            opentypeFeaturesURL.hash = `#opentype-feature-code-panel#L${lineno}:${column}`;
             return html.a(
               {
                 href: opentypeFeaturesURL,

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -228,10 +228,17 @@ export default class CharactersGlyphsPanel extends Panel {
     this.shapingDebuggerList.rowsElement.addEventListener("keydown", (event) =>
       this._shapingDebuggerHandleArrowLeftRight(event)
     );
+    this.shapingDebuggerList.showHeader = true;
     this.shapingDebuggerList.columnDescriptions = [
       {
         key: "formattedMessage",
         title: "Message",
+        width: 200,
+        minWidth: 100,
+      },
+      {
+        key: "sourceLocation",
+        title: "Feature source",
       },
     ];
     this.shapingDebuggerList.appendStyle(`
@@ -452,8 +459,6 @@ export default class CharactersGlyphsPanel extends Panel {
     // glyph index when doing RTL
     await this.sceneSettingsController.waitForKeyChange("positionedLines");
 
-    // const selectedMessage = this.sceneSettings.shapingDebuggerMessages[breakIndex];
-    // if (selectedMessage) {
     let selectedGlyph;
     const m = selectedMessage.message.match(/at (\d+(,\d+)*)/);
     if (m) {

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -256,7 +256,7 @@ export default class CharactersGlyphsPanel extends Panel {
               [item.sourceLocation]
             );
           } else {
-            return item.sourceLocation;
+            return item.sourceLocation?.split(/\\|\//).at(-1);
           }
         },
       },

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -244,7 +244,7 @@ export default class CharactersGlyphsPanel extends Panel {
           if (match) {
             const opentypeFeaturesURL = new URL(window.location);
             opentypeFeaturesURL.pathname = "fontinfo.html";
-            opentypeFeaturesURL.hash = `#opentype-feature-code-panel#L${match[1]}`;
+            opentypeFeaturesURL.hash = `#opentype-feature-code-panel#L${match[1]}:${match[2]}`;
             return html.a(
               {
                 href: opentypeFeaturesURL,

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -240,11 +240,11 @@ export default class CharactersGlyphsPanel extends Panel {
         key: "sourceLocation",
         title: "Feature source",
         get: (item) => {
-          const parts = item.sourceLocation?.split(":");
-          if (parts && parts[0] == "<features>") {
+          const match = item.sourceLocation?.match(/^<features>:(\d+):(\d+)/);
+          if (match) {
             const opentypeFeaturesURL = new URL(window.location);
             opentypeFeaturesURL.pathname = "fontinfo.html";
-            opentypeFeaturesURL.hash = `#opentype-feature-code-panel#L${parts[1]}`;
+            opentypeFeaturesURL.hash = `#opentype-feature-code-panel#L${match[1]}`;
             return html.a(
               {
                 href: opentypeFeaturesURL,

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -239,6 +239,23 @@ export default class CharactersGlyphsPanel extends Panel {
       {
         key: "sourceLocation",
         title: "Feature source",
+        get: (item) => {
+          const parts = item.sourceLocation?.split(":");
+          if (parts && parts[0] == "<features>") {
+            const opentypeFeaturesURL = new URL(window.location);
+            opentypeFeaturesURL.pathname = "fontinfo.html";
+            opentypeFeaturesURL.hash = `#opentype-feature-code-panel#L${parts[1]}`;
+            return html.a(
+              {
+                href: opentypeFeaturesURL,
+                target: `fontra.fontinfo.${this.editorController.projectIdentifier}`,
+              },
+              [item.sourceLocation]
+            );
+          } else {
+            return item.sourceLocation;
+          }
+        },
       },
     ];
     this.shapingDebuggerList.appendStyle(`
@@ -246,6 +263,11 @@ export default class CharactersGlyphsPanel extends Panel {
         padding: 0em 0.2em 0em 0.2em;
         border-radius: 0.25em;
         font-family: monospace;
+      }
+
+      a {
+        color: unset;
+        text-decoration: unset;
       }
 
       .table-tag {

--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -465,7 +465,10 @@ export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
       return;
     }
 
-    const match = urlData.match(/^(?<type>L|C)(?<N>\d+)(-(?<M>\d+))?$/);
+    const match = urlData.match(
+      /^(?<type>L|C)(?<N>\d+)((-(?<M>\d+))|(:(?<COL>\d+)))?$/
+    );
+
     if (!match) {
       return;
     }
@@ -473,13 +476,14 @@ export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
     const lineNumbers = match.groups.type == "L";
     let N = parseInt(match.groups.N);
     let M = match.groups.M ? parseInt(match.groups.M) : undefined;
+    const COL = match.groups.COL ? parseInt(match.groups.COL) : 0;
 
     if (lineNumbers) {
       const doc = this.editorView.state.doc;
       if (N <= doc.lines) {
         const lineN = doc.line(N);
         const lineM = M >= N ? doc.line(Math.min(M, doc.lines)) : undefined;
-        N = lineN.from;
+        N = Math.min(lineN.from + COL, doc.length);
         M = Math.min((lineM ? lineM.to : lineN.to) + 1, doc.length);
       } else {
         N = doc.length;

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -43,6 +43,7 @@ shaperFontTables = {
     "head",
     "maxp",
     "name",
+    "Debg",
     "GDEF",
     "GSUB",
     "GPOS",


### PR DESCRIPTION
1. Add `Debg` table when compiling a shaper font
2. When debugging, read the `Debg` table to get info about where a lookup was defined in the feature code, add a column with this info to the debugger list
3. Clicking an item in this column will navigate to the specified location in the feature code (if Fontra compiled the shaper font itself, that is)