### PR TITLE
Only raise NotImplementedError if there are rules

### DIFF
--- a/src/fontra/backends/base.py
+++ b/src/fontra/backends/base.py
@@ -93,4 +93,7 @@ class WritableBaseBackend(ReadableBaseBackend):
     async def putConditionalSubstitutions(
         self, substitutions: ConditionalSubstitutions
     ) -> None:
-        raise NotImplementedError()
+        if substitutions.rules:
+            raise NotImplementedError(
+                "writing conditional substitutions is not supported"
+            )


### PR DESCRIPTION
Make the default implementation for `putConditionalSubstitutions` only raise `NotImplementedError` if there are rules. This fixes .rcjk export.