### PR TITLE
Fix avar (un)mapping for conditional substitutions when preparing shaper font

### DIFF
--- a/src-js/fontra-core/src/shaper-controller.js
+++ b/src-js/fontra-core/src/shaper-controller.js
@@ -170,6 +170,7 @@ export class ShaperController {
     const conditionalSubstitutions = prepareConditionalSubstitutions(
       await this.fontController.getConditionalSubstitutions(),
       this.fontController.fontAxes,
+      this.fontController.fontAxesSourceSpace,
       this.fontController.glyphMap
     );
 
@@ -319,13 +320,25 @@ function ensureNotdef(glyphOrder) {
   glyphOrder.unshift(".notdef");
 }
 
-function prepareConditionalSubstitutions(substitutions, fontAxes, glyphMap) {
+function prepareConditionalSubstitutions(
+  substitutions,
+  fontAxes,
+  fontAxesSourceSpace,
+  glyphMap
+) {
   const axesByName = Object.fromEntries(fontAxes.map((axis) => [axis.name, axis]));
   const mapFuncs = Object.fromEntries(
-    fontAxes.map((axis) => {
-      const mapping = axis.mapping
-        ? Object.fromEntries(axis.mapping.map(([a, b]) => [b, a]))
-        : null;
+    fontAxesSourceSpace.map((axisSourceSpace) => {
+      const axis = axesByName[axisSourceSpace.name];
+      // We don't "unapply" avar mapping, we just *scale* from source space to user space
+      const mapping =
+        axis.mapping && axis.minValue != undefined
+          ? {
+              [axisSourceSpace.minValue]: axis.minValue,
+              [axisSourceSpace.defaultValue]: axis.defaultValue,
+              [axisSourceSpace.maxValue]: axis.maxValue,
+            }
+          : null;
       return [axis.name, mapping ? (v) => piecewiseLinearMap(v, mapping) : (v) => v];
     })
   );

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/font-data.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/font-data.json
@@ -1,0 +1,173 @@
+{
+"unitsPerEm": 2048,
+"fontInfo": {
+"familyName": "Cond Subst Test",
+"versionMajor": 1,
+"versionMinor": 0,
+"copyright": "",
+"trademark": "",
+"description": "",
+"sampleText": "",
+"designer": "",
+"designerURL": "",
+"manufacturer": "",
+"manufacturerURL": "",
+"licenseDescription": "",
+"licenseInfoURL": "",
+"vendorID": ""
+},
+"axes": {
+"axes": [
+{
+"name": "Weight",
+"label": "Weight",
+"tag": "wght",
+"minValue": 400,
+"defaultValue": 400,
+"maxValue": 900,
+"mapping": [
+[
+400,
+160
+],
+[
+500,
+203
+],
+[
+600,
+220
+],
+[
+700,
+253
+],
+[
+800,
+313
+],
+[
+900,
+384
+]
+]
+}
+]
+},
+"sources": {
+"Black": {
+"name": "Black",
+"location": {
+"Weight": 384
+},
+"lineMetricsHorizontalLayout": {
+"ascender": {
+"value": 1300,
+"zone": 20
+},
+"capHeight": {
+"value": 1300,
+"zone": 20
+},
+"xHeight": {
+"value": 850,
+"zone": 20
+},
+"descender": {
+"value": -300,
+"zone": -20
+},
+"baseline": {
+"value": 0,
+"zone": -20
+}
+}
+},
+"Regular": {
+"name": "Regular",
+"location": {
+"Weight": 160
+},
+"lineMetricsHorizontalLayout": {
+"ascender": {
+"value": 1300,
+"zone": 20
+},
+"capHeight": {
+"value": 1300,
+"zone": 20
+},
+"xHeight": {
+"value": 850,
+"zone": 20
+},
+"descender": {
+"value": -300,
+"zone": -20
+},
+"baseline": {
+"value": 0,
+"zone": -20
+}
+}
+}
+},
+"conditionalSubstitutions": {
+"featureTags": [
+"rvrn"
+],
+"rules": [
+{
+"name": "Weight.205",
+"conditionSets": [
+{
+"conditions": [
+{
+"name": "Weight",
+"minValue": 205,
+"maxValue": 384
+}
+]
+}
+],
+"substitutions": {
+"fi": "fi.rvrn"
+}
+},
+{
+"name": "Weight.280",
+"conditionSets": [
+{
+"conditions": [
+{
+"name": "Weight",
+"minValue": 280,
+"maxValue": 384
+}
+]
+}
+],
+"substitutions": {
+"cent": "cent.rvrn"
+}
+},
+{
+"name": "Weight.310",
+"conditionSets": [
+{
+"conditions": [
+{
+"name": "Weight",
+"minValue": 310,
+"maxValue": 384
+}
+]
+}
+],
+"substitutions": {
+"oslash": "oslash.rvrn"
+}
+}
+]
+}
+}

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyph-info.csv
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyph-info.csv
@@ -1,0 +1,8 @@
+glyph name;code points
+cent;U+00A2
+cent.rvrn;
+fi;U+FB01
+fi.rvrn;
+oslash;U+00F8
+oslash.rvrn;
+space;U+0020

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/cent.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/cent.json
@@ -1,0 +1,27 @@
+{
+"name": "cent",
+"sources": [
+{
+"name": "",
+"layerName": "Regular",
+"locationBase": "Regular"
+},
+{
+"name": "",
+"layerName": "Black",
+"locationBase": "Black"
+}
+],
+"layers": {
+"Black": {
+"glyph": {
+"xAdvance": 800
+}
+},
+"Regular": {
+"glyph": {
+"xAdvance": 800
+}
+}
+}
+}

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/cent.rvrn.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/cent.rvrn.json
@@ -1,0 +1,27 @@
+{
+"name": "cent.rvrn",
+"sources": [
+{
+"name": "",
+"layerName": "Regular",
+"locationBase": "Regular"
+},
+{
+"name": "",
+"layerName": "Black",
+"locationBase": "Black"
+}
+],
+"layers": {
+"Black": {
+"glyph": {
+"xAdvance": 800
+}
+},
+"Regular": {
+"glyph": {
+"xAdvance": 800
+}
+}
+}
+}

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/fi.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/fi.json
@@ -1,0 +1,27 @@
+{
+"name": "fi",
+"sources": [
+{
+"name": "",
+"layerName": "Regular",
+"locationBase": "Regular"
+},
+{
+"name": "",
+"layerName": "Black",
+"locationBase": "Black"
+}
+],
+"layers": {
+"Black": {
+"glyph": {
+"xAdvance": 800
+}
+},
+"Regular": {
+"glyph": {
+"xAdvance": 800
+}
+}
+}
+}

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/fi.rvrn.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/fi.rvrn.json
@@ -1,0 +1,27 @@
+{
+"name": "fi.rvrn",
+"sources": [
+{
+"name": "",
+"layerName": "Regular",
+"locationBase": "Regular"
+},
+{
+"name": "",
+"layerName": "Black",
+"locationBase": "Black"
+}
+],
+"layers": {
+"Black": {
+"glyph": {
+"xAdvance": 800
+}
+},
+"Regular": {
+"glyph": {
+"xAdvance": 800
+}
+}
+}
+}

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/oslash.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/oslash.json
@@ -1,0 +1,27 @@
+{
+"name": "oslash",
+"sources": [
+{
+"name": "",
+"layerName": "Regular",
+"locationBase": "Regular"
+},
+{
+"name": "",
+"layerName": "Black",
+"locationBase": "Black"
+}
+],
+"layers": {
+"Black": {
+"glyph": {
+"xAdvance": 800
+}
+},
+"Regular": {
+"glyph": {
+"xAdvance": 800
+}
+}
+}
+}

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/oslash.rvrn.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/oslash.rvrn.json
@@ -1,0 +1,27 @@
+{
+"name": "oslash.rvrn",
+"sources": [
+{
+"name": "",
+"layerName": "Regular",
+"locationBase": "Regular"
+},
+{
+"name": "",
+"layerName": "Black",
+"locationBase": "Black"
+}
+],
+"layers": {
+"Black": {
+"glyph": {
+"xAdvance": 800
+}
+},
+"Regular": {
+"glyph": {
+"xAdvance": 800
+}
+}
+}
+}

--- a/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/space.json
+++ b/src-js/fontra-core/tests/data/cond-subst/cond-subst.fontra/glyphs/space.json
@@ -1,0 +1,27 @@
+{
+"name": "space",
+"sources": [
+{
+"name": "",
+"layerName": "Regular",
+"locationBase": "Regular"
+},
+{
+"name": "",
+"layerName": "Black",
+"locationBase": "Black"
+}
+],
+"layers": {
+"Black": {
+"glyph": {
+"xAdvance": 800
+}
+},
+"Regular": {
+"glyph": {
+"xAdvance": 800
+}
+}
+}
+}

--- a/src-js/fontra-core/tests/test-shaper.js
+++ b/src-js/fontra-core/tests/test-shaper.js
@@ -1814,6 +1814,70 @@ describe("test conditional substitutions", () => {
   });
 });
 
+describe("test conditional substitutions with mapping", () => {
+  it("test conditional substitutions with mapping", async () => {
+    const testFontPath = moduleDirName.joinPath(
+      "data",
+      "cond-subst",
+      "cond-subst.fontra"
+    );
+
+    const shapeFunc = await getEmulatedShapeFuncForPath(testFontPath);
+
+    const inputCodePoints = [..."¢øﬁ"].map(ord);
+
+    const { glyphs: glyphs1 } = await shapeFunc(inputCodePoints);
+    const glyphNames1 = glyphs1.map((g) => g.glyphname);
+    expect(glyphNames1).to.deep.equal(["cent", "oslash", "fi"]);
+
+    const { glyphs: glyphs2 } = await shapeFunc(inputCodePoints, {
+      variations: { wght: 500 },
+    });
+    const glyphNames2 = glyphs2.map((g) => g.glyphname);
+    expect(glyphNames2).to.deep.equal(["cent", "oslash", "fi"]);
+
+    // Source coords *scaled* to User coords (but not unapplying avar)
+    // conditionalSubstitutions = {
+    //   featureTags: ["rvrn"],
+    //   rules: [
+    //     [[{ wght: [500.44642857142856, 900] }], { fi: "fi.rvrn" }],
+    //     [[{ wght: [667.8571428571429, 900] }], { cent: "cent.rvrn" }],
+    //     [[{ wght: [734.8214285714286, 900] }], { oslash: "oslash.rvrn" }],
+    //   ],
+    // };
+
+    const { glyphs: glyphs3 } = await shapeFunc(inputCodePoints, {
+      variations: { wght: 501 },
+    });
+    const glyphNames3 = glyphs3.map((g) => g.glyphname);
+    expect(glyphNames3).to.deep.equal(["cent", "oslash", "fi.rvrn"]);
+
+    const { glyphs: glyphs4 } = await shapeFunc(inputCodePoints, {
+      variations: { wght: 667 },
+    });
+    const glyphNames4 = glyphs4.map((g) => g.glyphname);
+    expect(glyphNames4).to.deep.equal(["cent", "oslash", "fi.rvrn"]);
+
+    const { glyphs: glyphs5 } = await shapeFunc(inputCodePoints, {
+      variations: { wght: 668 },
+    });
+    const glyphNames5 = glyphs5.map((g) => g.glyphname);
+    expect(glyphNames5).to.deep.equal(["cent.rvrn", "oslash", "fi.rvrn"]);
+
+    const { glyphs: glyphs6 } = await shapeFunc(inputCodePoints, {
+      variations: { wght: 734 },
+    });
+    const glyphNames6 = glyphs6.map((g) => g.glyphname);
+    expect(glyphNames6).to.deep.equal(["cent.rvrn", "oslash", "fi.rvrn"]);
+
+    const { glyphs: glyphs7 } = await shapeFunc(inputCodePoints, {
+      variations: { wght: 735 },
+    });
+    const glyphNames7 = glyphs7.map((g) => g.glyphname);
+    expect(glyphNames7).to.deep.equal(["cent.rvrn", "oslash.rvrn", "fi.rvrn"]);
+  });
+});
+
 function stripGlyphIDs(glyphs) {
   return glyphs.map((glyph) => {
     glyph = { ...glyph };


### PR DESCRIPTION
This fixes #2556