### PR TITLE
Center selection when jumping to feature code link

### DIFF
--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -504,7 +504,7 @@ export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
         ],
         0
       ),
-      scrollIntoView: true,
+      effects: EditorView.scrollIntoView(spanFrom, { y: "center" }),
     });
 
     this.editorView.focus();


### PR DESCRIPTION
The `scrollIntoView: true` is equivalent EditorView.scrollIntoView() with default options which is `y: "nearest"`, but this would often scroll to the selection just enough to make the line appear at the end of the view, which is not very helpful.

Using EditorView.scrollIntoView() so we can set `y: "center"`, which is nicer as the start of the span becomes in the middle of the page.