### PR TITLE
Improve message formatting in feature debugger a bit

### DIFF
--- a/src-js/fontra-core/src/shaper.js
+++ b/src-js/fontra-core/src/shaper.js
@@ -362,11 +362,8 @@ class HBShaper extends ShaperBase {
               lookupId
             ]
           : undefined;
-        const sourceLocation = sourceInfo?.[1]
-          ? `${sourceInfo[0]} (${sourceInfo[1]})`
-          : sourceInfo
-          ? `${sourceInfo[0]}`
-          : undefined;
+        const sourceLocation = sourceInfo?.[0];
+        const lookupName = sourceInfo?.[1];
 
         messages.push({
           message,
@@ -374,6 +371,7 @@ class HBShaper extends ShaperBase {
             this._previousGlyphsSerialized &&
             glyphsSerialized != this._previousGlyphsSerialized,
           sourceLocation,
+          lookupName,
         });
 
         this._previousGlyphsSerialized = glyphsSerialized;

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -253,7 +253,7 @@ export default class CharactersGlyphsPanel extends Panel {
                 href: opentypeFeaturesURL,
                 target: `fontra.fontinfo.${this.editorController.projectIdentifier}`,
               },
-              [item.sourceLocation]
+              [`${lineno}:${column}`]
             );
           } else {
             return item.sourceLocation?.split(/\\|\//).at(-1);

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -233,7 +233,7 @@ export default class CharactersGlyphsPanel extends Panel {
       {
         key: "formattedMessage",
         title: "Message",
-        width: 200,
+        width: 250,
         minWidth: 100,
       },
       {

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -285,6 +285,10 @@ export default class CharactersGlyphsPanel extends Panel {
         background-color: #C8F5;
       }
 
+      .lookup-name {
+        background-color: #CFC5;
+      }
+
       .indent-block {
         display: inline-block;
         width: 1em; // don't change: it'll change the icon size
@@ -766,13 +770,14 @@ function formatShaperMessage(message, lookupName) {
   const parts = [
     message
       .replace(/(lookup \d+) (feature '.+?')/, `$2 $1`)
-      .replace(/lookup \d+/, lookupName ? `$& (${lookupName})` : "$&"),
+      .replace(/lookup \d+/, lookupName ? `$& '${lookupName}'` : "$&"),
   ];
 
   for (const [cls, regex] of [
     ["ot-tag table-tag", /(?<=table )(GSUB|GPOS)/],
     ["ot-tag script-tag", /(?<=script tag )'(.+?)'/],
     ["ot-tag feature-tag", /(?<=feature )'(.+?)'/],
+    ["ot-tag lookup-name", /(?<=lookup \d+ )'(.+?)'/],
   ]) {
     const part = parts.at(-1);
     const m = part.match(regex);

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -613,7 +613,7 @@ export default class CharactersGlyphsPanel extends Panel {
         changedElement,
         ...repeat(level, () => html.span({ class: "indent-block" })),
         foldingChevron,
-        ...formatShaperMessage(message),
+        ...formatShaperMessage(message, messageItem.lookupName),
       ]);
     });
 
@@ -762,8 +762,12 @@ function sameGlyphNames(items1, items2) {
   return key1 == key2;
 }
 
-function formatShaperMessage(message) {
-  const parts = [message];
+function formatShaperMessage(message, lookupName) {
+  const parts = [
+    message
+      .replace(/(lookup \d+) (feature '.+?')/, `$2 $1`)
+      .replace(/lookup \d+/, lookupName ? `$& (${lookupName})` : "$&"),
+  ];
 
   for (const [cls, regex] of [
     ["ot-tag table-tag", /(?<=table )(GSUB|GPOS)/],

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -238,7 +238,7 @@ export default class CharactersGlyphsPanel extends Panel {
       },
       {
         key: "sourceLocation",
-        title: "Feature source",
+        title: "Source location",
         get: (item) => {
           const match = item.sourceLocation?.match(
             /^<features>:(?<lineno>\d+):(?<column>\d+)/


### PR DESCRIPTION
* Show lookup name in the Message column after the lookup number, not in the Feature source
* Re-order the message to have feature first, so they align better since lookup name vary in length
* Drop `<feature>:` part for Feature source for shaper fonts, it is a dummy file name and it occupies precious space.
* Make the Message column a bit wider since the Feature source column does not need much space now.

Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cc044ce1-8867-45af-be59-5ddfaef65d42" />

After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b5e561ab-aa84-47de-ba17-c5ac5e5cd68b" />