### PR TITLE
Fix canvas interpolation issue

### DIFF
--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -92,10 +92,33 @@ export class CanvasController {
     const width = this.canvasWidth;
     const height = this.canvasHeight;
     const scale = this.devicePixelRatio;
-    this.canvas.width = Math.floor(width * scale);
-    this.canvas.height = Math.floor(height * scale);
-    this.canvas.style.width = width + "px";
-    this.canvas.style.height = height + "px";
+
+    // We want to be sure that we have at least enough pixels to cover the
+    // entire area of the canvas, accounting for dpi and browser scaling.
+    //
+    // To do this, we take the ceiling of the CSS pixel width and height
+    // values multiplied by the pixel ratio, which is a number that should
+    // be guaranteed to be equal to or greater than the final number of screen
+    // pixels that the canvas element (or rather its container) takes up.
+    this.canvas.width = Math.ceil(width * scale);
+    this.canvas.height = Math.ceil(height * scale);
+
+    // We then take those numbers and divide them back down by the scale
+    // and tell the browser to display the canvas at that many CSS pixels
+    // wide and tall. This should ensure that there is a 1 to 1 mapping
+    // between pixels in the canvas's data buffer and pixels as displayed
+    // on screen for the user.
+    //
+    // If we didn't do this, and just used the container's size, then the
+    // browser might end up stretching the canvas data very slightly to
+    // make it fit the final size. This isn't ideal but usually isn't
+    // noticeable except in Safari where the scaling is switched to
+    // nearest neighbor if the texture is more than 2K pixels wide,
+    // which can cause a column or row of pixels in the center of
+    // the canvas to be repeated and it's very noticeable.
+    this.canvas.style.width = this.canvas.width / scale + "px";
+    this.canvas.style.height = this.canvas.height / scale + "px";
+
     const parentOffsetX = this.canvas.parentElement.offsetLeft;
     const parentOffsetY = this.canvas.parentElement.offsetTop;
 


### PR DESCRIPTION
I noticed an issue in Safari (26.4) where the center column of pixels on the canvas was being repeated, causing jank right in the middle of the working area.

|the issue|highlighted|
|-|-|
|<img width="190" height="486" alt="image" src="https://github.com/user-attachments/assets/15c65c56-0bf3-40a6-84a4-eac523038228" />|<img width="294" height="836" alt="image" src="https://github.com/user-attachments/assets/58c5e6f3-b867-4cd3-a18f-bc453e7f464c" />|

To reproduce this in Safari, use a high DPI display and make sure the canvas is more than 2K pixels wide, then fiddle with the width of one of the sidebars. 50% of sidebar widths will cause this problem.

The problem is revealed by Safari's behavior of switching to nearest neighbor interpolation for scaling the canvas texture when it's more than 2K px on an axis, but the underlying issue is that almost always the canvas texture has to be scaled (stretched!) a tiny bit, if the sidebars are out and have been adjusted in size at all. It's not usually noticeable though it does degrade the quality a tiny bit.

The root cause is that the canvas texture size was being computed as `floor(<width|height> * scale)`, which, when `width`/`height` or `scale` are not integers will half the time result in the texture being slightly narrower than the actual pixel size the element ends up being displayed at, meaning it has to be stretched by a pixel.

Rather than trying to determine what size the element will be, the solution I think is best (and so implemented) is to resize the canvas element to explicitly be the appropriate number of CSS pixels so that it will match the texture size exactly when scaled to screen pixels and rendered by the browser.