### PR TITLE
[shaping] Make dumb shaper dumber

### DIFF
--- a/src-js/fontra-core/src/shaper.js
+++ b/src-js/fontra-core/src/shaper.js
@@ -536,14 +536,13 @@ class DumbShaper extends ShaperBase {
     for (const [i, codePoint] of enumerate(codePoints)) {
       const glyphName = this.nominalGlyph(codePoint);
       const xAdvance = Math.round(glyphObjects[glyphName]?.xAdvance ?? 500);
-      const isMark = this.isGlyphMarkFunc(glyphName);
 
       glyphs.push({
         codepoint: glyphName ? this.glyphNameToID[glyphName] : 0,
         cluster: i,
         glyphname: glyphName ?? ".notdef",
-        mark: isMark,
-        xAdvance: isMark ? 0 : xAdvance,
+        mark: false,
+        xAdvance: xAdvance,
         yAdvance: 0,
         xOffset: 0,
         yOffset: 0,
@@ -554,22 +553,13 @@ class DumbShaper extends ShaperBase {
       glyphs.reverse();
     }
 
-    const skipFeatures = this._getInitialSkipEmulatedFeatures(options.emulatedFeatures);
-    this.applyEmulatedPositioning(
-      glyphs,
-      glyphObjects,
-      skipFeatures,
-      options.kerningPairFunc,
-      options.direction
-    );
-
     const requiredGlyphs = glyphs.map((g) => g.glyphname);
 
-    return { glyphs, requiredGlyphs };
+    return { glyphs, requiredGlyphs, direction };
   }
 
   getFeatureInfo(otTableTag) {
-    return super.getFeatureInfo(otTableTag) ?? {};
+    return {};
   }
 
   getScriptAndLanguageInfo() {

--- a/src-js/fontra-core/src/shaper.js
+++ b/src-js/fontra-core/src/shaper.js
@@ -535,14 +535,13 @@ class DumbShaper extends ShaperBase {
 
     for (const [i, codePoint] of enumerate(codePoints)) {
       const glyphName = this.nominalGlyph(codePoint);
-      const xAdvance = Math.round(glyphObjects[glyphName]?.xAdvance ?? 500);
 
       glyphs.push({
         codepoint: glyphName ? this.glyphNameToID[glyphName] : 0,
         cluster: i,
         glyphname: glyphName ?? ".notdef",
         mark: false,
-        xAdvance: xAdvance,
+        xAdvance: Math.round(glyphObjects[glyphName]?.xAdvance ?? 500),
         yAdvance: 0,
         xOffset: 0,
         yOffset: 0,

--- a/src-js/fontra-core/tests/test-shaper.js
+++ b/src-js/fontra-core/tests/test-shaper.js
@@ -28,7 +28,7 @@ describe("shaper tests", () => {
 
   const testInputCodePoints = [..."😻VABCÄS"].map((c) => ord(c));
 
-  function getExpectedGlyphs(useGlyphObjects) {
+  function getExpectedGlyphs(useGlyphObjects, applyShaping = true) {
     return [
       {
         codepoint: 0,
@@ -43,7 +43,7 @@ describe("shaper tests", () => {
       {
         codepoint: 24,
         cluster: 1,
-        xAdvance: useGlyphObjects ? 301 : 300,
+        xAdvance: !applyShaping ? 401 : useGlyphObjects ? 301 : 300,
         yAdvance: 0,
         xOffset: 0,
         yOffset: 0,
@@ -312,7 +312,7 @@ describe("shaper tests", () => {
       kerningPairFunc: (g1, g2) => kerning.getGlyphPairValue(g1, g2),
     });
 
-    expect(glyphs).to.deep.equal(getExpectedGlyphs(true));
+    expect(glyphs).to.deep.equal(getExpectedGlyphs(true, false));
   });
 
   it("test DumbShaper RTL", () => {
@@ -366,23 +366,25 @@ describe("shaper tests", () => {
     },
   ];
 
-  const defaultInsertMarkers = [
-    { tag: "curs", lookupId: undefined },
-    { tag: "kern", lookupId: undefined },
-    { tag: "mark", lookupId: undefined },
-    { tag: "mkmk", lookupId: undefined },
-  ];
-
   it("test applyKerning skip marks", () => {
     const shaper = getShaper({
       nominalGlyphFunc,
       glyphOrder,
-      isGlyphMarkFunc,
-      insertMarkers: defaultInsertMarkers,
     });
-    const { glyphs } = shaper.shape(testInputCodePointsKerningSkipMarks, glyphObjects, {
-      kerningPairFunc: (g1, g2) => kerning.getGlyphPairValue(g1, g2),
+    const { glyphs } = shaper.shape(
+      testInputCodePointsKerningSkipMarks,
+      glyphObjects,
+      {}
+    );
+
+    glyphs.forEach((glyph) => {
+      glyph.mark = isGlyphMarkFunc(glyph.glyphname);
+      if (glyph.mark) {
+        glyph.xAdvance = 0;
+      }
     });
+
+    applyKerning(glyphs, (g1, g2) => kerning.getGlyphPairValue(g1, g2));
 
     expect(glyphs).to.deep.equal(expectedGlyphsKerningSkipMarks);
   });

--- a/src-js/fontra-core/tests/test-shaper.js
+++ b/src-js/fontra-core/tests/test-shaper.js
@@ -332,61 +332,76 @@ describe("shaper tests", () => {
     ]);
   });
 
-  const testInputCodePointsKerningSkipMarks = [..."V\u0304A"].map((c) => ord(c));
-  const expectedGlyphsKerningSkipMarks = [
-    {
-      codepoint: 24,
-      cluster: 0,
-      glyphname: "V",
-      mark: false,
-      xAdvance: 301,
-      yAdvance: 0,
-      xOffset: 0,
-      yOffset: 0,
-    },
-    {
-      codepoint: 51,
-      cluster: 1,
-      glyphname: "macroncomb",
-      mark: true,
-      xAdvance: 0,
-      yAdvance: 0,
-      xOffset: 0,
-      yOffset: 0,
-    },
-    {
-      codepoint: 1,
-      cluster: 2,
-      glyphname: "A",
-      mark: false,
-      xAdvance: 396,
-      yAdvance: 0,
-      xOffset: 0,
-      yOffset: 0,
-    },
-  ];
-
   it("test applyKerning skip marks", () => {
-    const shaper = getShaper({
-      nominalGlyphFunc,
-      glyphOrder,
-    });
-    const { glyphs } = shaper.shape(
-      testInputCodePointsKerningSkipMarks,
-      glyphObjects,
-      {}
-    );
+    const glyphs = [
+      {
+        codepoint: 24,
+        cluster: 0,
+        glyphname: "V",
+        mark: false,
+        xAdvance: 401,
+        yAdvance: 0,
+        xOffset: 0,
+        yOffset: 0,
+      },
+      {
+        codepoint: 51,
+        cluster: 1,
+        glyphname: "macroncomb",
+        mark: true,
+        xAdvance: 0,
+        yAdvance: 0,
+        xOffset: 0,
+        yOffset: 0,
+      },
+      {
+        codepoint: 1,
+        cluster: 2,
+        glyphname: "A",
+        mark: false,
+        xAdvance: 396,
+        yAdvance: 0,
+        xOffset: 0,
+        yOffset: 0,
+      },
+    ];
 
-    glyphs.forEach((glyph) => {
-      glyph.mark = isGlyphMarkFunc(glyph.glyphname);
-      if (glyph.mark) {
-        glyph.xAdvance = 0;
-      }
-    });
+    const expectedOutputGlyphs = [
+      {
+        codepoint: 24,
+        cluster: 0,
+        glyphname: "V",
+        mark: false,
+        xAdvance: 301,
+        yAdvance: 0,
+        xOffset: 0,
+        yOffset: 0,
+      },
+      {
+        codepoint: 51,
+        cluster: 1,
+        glyphname: "macroncomb",
+        mark: true,
+        xAdvance: 0,
+        yAdvance: 0,
+        xOffset: 0,
+        yOffset: 0,
+      },
+      {
+        codepoint: 1,
+        cluster: 2,
+        glyphname: "A",
+        mark: false,
+        xAdvance: 396,
+        yAdvance: 0,
+        xOffset: 0,
+        yOffset: 0,
+      },
+    ];
 
     applyKerning(glyphs, (g1, g2) => kerning.getGlyphPairValue(g1, g2));
 
-    expect(glyphs).to.deep.equal(expectedGlyphsKerningSkipMarks);
+    expect(glyphs).to.deep.equal(expectedOutputGlyphs);
   });
 
   it("test getGlyphNameCodePoint", () => {


### PR DESCRIPTION
Make dumb shaper dumber: we don't want it to do anything beyond laying out the characters sequentially

This fixes #2517.

This disables all emulated GPOS functionality when the "Apply text shaping and features" option is off.