### PR TITLE
canvas: make min zoom limit relative to em size (UPM)

### DIFF
--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,5 +1,5 @@
 import { normalizeRect, rectCenter, validateRect } from "./rectangle.js";
-import { assert, consolidateCalls, isNumber, withSavedState } from "./utils.js";
+import { assert, clamp, consolidateCalls, isNumber, withSavedState } from "./utils.js";
 
 const DEFAULT_MIN_MAGNIFICATION = 0.005;
 const DEFAULT_MAX_MAGNIFICATION = 200;
@@ -211,13 +211,14 @@ export class CanvasController {
   }
 
   _clampMagnification() {
-    const old_magnification = this.magnification;
-    this.magnification = Math.min(
-      Math.max(this.magnification, this._minMagnification),
+    const oldMagnification = this.magnification;
+    this.magnification = clamp(
+      this.magnification,
+      this._minMagnification,
       this._maxMagnification
     );
 
-    if (this.magnification !== old_magnification) {
+    if (this.magnification !== oldMagnification) {
       this._magnificationChangedCallback?.(this.magnification);
       this.requestUpdate();
       this._dispatchEvent("viewBoxChanged", "magnification");
@@ -260,8 +261,9 @@ export class CanvasController {
     const prevMagnification = this.magnification;
 
     this.magnification = this.magnification * zoomFactor;
-    this.magnification = Math.min(
-      Math.max(this.magnification, this.minMagnification),
+    this.magnification = clamp(
+      this.magnification,
+      this.minMagnification,
       this.maxMagnification
     );
     zoomFactor = this.magnification / prevMagnification;

--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,17 +1,36 @@
 import { normalizeRect, rectCenter, validateRect } from "./rectangle.js";
 import { assert, consolidateCalls, isNumber, withSavedState } from "./utils.js";
 
-const MIN_MAGNIFICATION = 0.005;
-const MAX_MAGNIFICATION = 200;
+// Minimum pixels per em and maximum pixels per unit for zooming out and in.
+//
+// Note that these are not _screen pixels_, they are css "pixels" which are
+// scaled by screen DPI and browser zoom level. So on a high dpi display or
+// in a browser with a higher zoom level set, the minimum and maximum scale
+// in _screen pixels_ will be higher (for both).
+//
+// Zooming out is capped by pixels per em to allow a consistent size when
+// zoomed all the way out at different em scales, and zooming in is capped
+// by pixels per unit to allow a consistent 1 unit size when zoomed all the
+// way in regardless of em scale.
+//
+// These values are chosen arbitrarily and in the future there may
+// be some merit to letting users configure this to their own taste.
+const MIN_PIX_PER_EM = 5;
+const MAX_PIX_PER_UNIT = 200;
 
 export class CanvasController {
-  constructor(canvas, magnificationChangedCallback) {
+  constructor(canvas, magnificationChangedCallback, getUnitsPerEm) {
     this.canvas = canvas; // The HTML5 Canvas object
     this.context = canvas.getContext("2d");
     this.sceneView = undefined; // will be set later
 
     this.magnification = 1;
     this.origin = { x: this.canvasWidth / 2, y: 0.85 * this.canvasHeight }; // TODO choose y based on initial canvas height
+
+    // The consumer of CanvasController must provide a function that returns
+    // the current units per em. This is used to set the lower limit on the
+    // magnification for zooming out.
+    this._getUnitsPerEm = getUnitsPerEm;
 
     this._magnificationChangedCallback = magnificationChangedCallback;
 
@@ -207,6 +226,19 @@ export class CanvasController {
     delete this._initialMagnification;
   }
 
+  get minMagnification() {
+    // The lower magnification limit is implemented relative to UPM
+    // to provide a consistent em size when zoomed all the way out.
+    return MIN_PIX_PER_EM / this._getUnitsPerEm();
+  }
+
+  get maxMagnification() {
+    // The upper magnification limit is implemented relative to individual
+    // units, so that when zoomed all the way in the size of an individual
+    // unit is the same regardless of em size.
+    return MAX_PIX_PER_UNIT;
+  }
+
   _doPinchMagnify(event, zoomFactor) {
     assert(isNumber(zoomFactor));
     const center = this.localPoint({ x: event.pageX, y: event.pageY });
@@ -214,8 +246,8 @@ export class CanvasController {
 
     this.magnification = this.magnification * zoomFactor;
     this.magnification = Math.min(
-      Math.max(this.magnification, MIN_MAGNIFICATION),
-      MAX_MAGNIFICATION
+      Math.max(this.magnification, this.minMagnification),
+      this.maxMagnification
     );
     zoomFactor = this.magnification / prevMagnification;
 
@@ -309,10 +341,10 @@ export class CanvasController {
 
   getProposedViewBoxClampAdjustment(viewBox) {
     const magnification = this._getProposedViewBoxMagnification(viewBox);
-    if (magnification < MIN_MAGNIFICATION) {
-      return magnification / MIN_MAGNIFICATION;
-    } else if (magnification > MAX_MAGNIFICATION) {
-      return magnification / MAX_MAGNIFICATION;
+    if (magnification < this.minMagnification) {
+      return magnification / this.minMagnification;
+    } else if (magnification > this.maxMagnification) {
+      return magnification / this.maxMagnification;
     }
     return 1;
   }

--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -5,7 +5,7 @@ const DEFAULT_MIN_MAGNIFICATION = 0.005;
 const DEFAULT_MAX_MAGNIFICATION = 200;
 
 export class CanvasController {
-  constructor(canvas, magnificationChangedCallback, getUnitsPerEm) {
+  constructor(canvas, magnificationChangedCallback) {
     this.canvas = canvas; // The HTML5 Canvas object
     this.context = canvas.getContext("2d");
     this.sceneView = undefined; // will be set later
@@ -210,38 +210,40 @@ export class CanvasController {
     delete this._initialMagnification;
   }
 
+  _clampMagnification() {
+    const old_magnification = this.magnification;
+    this.magnification = Math.min(
+      Math.max(this.magnification, this._minMagnification),
+      this._maxMagnification
+    );
+
+    if (this.magnification !== old_magnification) {
+      this._magnificationChangedCallback?.(this.magnification);
+      this.requestUpdate();
+      this._dispatchEvent("viewBoxChanged", "magnification");
+    }
+  }
+
   set minMagnification(newValue) {
     // If there's no change then we don't have to do anything.
-    if (newValue == this._minMagnification) return;
+    if (newValue == this._minMagnification) {
+      return;
+    }
 
     this._minMagnification = newValue;
 
-    // If our magnification is within the new bound then we're done.
-    if (this.magnification >= this._minMagnification) return;
-
-    // Otherwise we have to update our magnification to keep it in bounds.
-    this.magnification = this._minMagnification;
-
-    this._magnificationChangedCallback?.(this.magnification);
-    this.requestUpdate();
-    this._dispatchEvent("viewBoxChanged", "magnification");
+    this._clampMagnification();
   }
 
   set maxMagnification(newValue) {
     // If there's no change then we don't have to do anything.
-    if (newValue == this._maxMagnification) return;
+    if (newValue == this._maxMagnification) {
+      return;
+    }
 
     this._maxMagnification = newValue;
 
-    // If our magnification is within the new bound then we're done.
-    if (this.magnification <= this._maxMagnification) return;
-
-    // Otherwise we have to update our magnification to keep it in bounds.
-    this.magnification = this._maxMagnification;
-
-    this._magnificationChangedCallback?.(this.magnification);
-    this.requestUpdate();
-    this._dispatchEvent("viewBoxChanged", "magnification");
+    this._clampMagnification();
   }
 
   get minMagnification() {

--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,22 +1,8 @@
 import { normalizeRect, rectCenter, validateRect } from "./rectangle.js";
 import { assert, consolidateCalls, isNumber, withSavedState } from "./utils.js";
 
-// Minimum pixels per em and maximum pixels per unit for zooming out and in.
-//
-// Note that these are not _screen pixels_, they are css "pixels" which are
-// scaled by screen DPI and browser zoom level. So on a high dpi display or
-// in a browser with a higher zoom level set, the minimum and maximum scale
-// in _screen pixels_ will be higher (for both).
-//
-// Zooming out is capped by pixels per em to allow a consistent size when
-// zoomed all the way out at different em scales, and zooming in is capped
-// by pixels per unit to allow a consistent 1 unit size when zoomed all the
-// way in regardless of em scale.
-//
-// These values are chosen arbitrarily and in the future there may
-// be some merit to letting users configure this to their own taste.
-const MIN_PIX_PER_EM = 5;
-const MAX_PIX_PER_UNIT = 200;
+const DEFAULT_MIN_MAGNIFICATION = 0.005;
+const DEFAULT_MAX_MAGNIFICATION = 200;
 
 export class CanvasController {
   constructor(canvas, magnificationChangedCallback, getUnitsPerEm) {
@@ -27,10 +13,8 @@ export class CanvasController {
     this.magnification = 1;
     this.origin = { x: this.canvasWidth / 2, y: 0.85 * this.canvasHeight }; // TODO choose y based on initial canvas height
 
-    // The consumer of CanvasController must provide a function that returns
-    // the current units per em. This is used to set the lower limit on the
-    // magnification for zooming out.
-    this._getUnitsPerEm = getUnitsPerEm;
+    this._minMagnification = DEFAULT_MIN_MAGNIFICATION;
+    this._maxMagnification = DEFAULT_MAX_MAGNIFICATION;
 
     this._magnificationChangedCallback = magnificationChangedCallback;
 
@@ -226,17 +210,46 @@ export class CanvasController {
     delete this._initialMagnification;
   }
 
+  set minMagnification(newValue) {
+    // If there's no change then we don't have to do anything.
+    if (newValue == this._minMagnification) return;
+
+    this._minMagnification = newValue;
+
+    // If our magnification is within the new bound then we're done.
+    if (this.magnification >= this._minMagnification) return;
+
+    // Otherwise we have to update our magnification to keep it in bounds.
+    this.magnification = this._minMagnification;
+
+    this._magnificationChangedCallback?.(this.magnification);
+    this.requestUpdate();
+    this._dispatchEvent("viewBoxChanged", "magnification");
+  }
+
+  set maxMagnification(newValue) {
+    // If there's no change then we don't have to do anything.
+    if (newValue == this._maxMagnification) return;
+
+    this._maxMagnification = newValue;
+
+    // If our magnification is within the new bound then we're done.
+    if (this.magnification <= this._maxMagnification) return;
+
+    // Otherwise we have to update our magnification to keep it in bounds.
+    this.magnification = this._maxMagnification;
+
+    this._magnificationChangedCallback?.(this.magnification);
+    this.requestUpdate();
+    this._dispatchEvent("viewBoxChanged", "magnification");
+  }
+
   get minMagnification() {
-    // The lower magnification limit is implemented relative to UPM
-    // to provide a consistent em size when zoomed all the way out.
-    return MIN_PIX_PER_EM / this._getUnitsPerEm();
+    return this._minMagnification;
   }
 
   get maxMagnification() {
-    // The upper magnification limit is implemented relative to individual
-    // units, so that when zoomed all the way in the size of an individual
-    // unit is the same regardless of em size.
-    return MAX_PIX_PER_UNIT;
+    return this._maxMagnification;
   }
 
   _doPinchMagnify(event, zoomFactor) {

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -122,8 +122,10 @@ export class EditorController extends ViewController {
     canvas.ondragleave = (event) => this._onDragLeave(event);
     canvas.ondrop = (event) => this._onDrop(event);
 
-    const canvasController = new CanvasController(canvas, (magnification) =>
-      this.canvasMagnificationChanged(magnification)
+    const canvasController = new CanvasController(
+      canvas,
+      (magnification) => this.canvasMagnificationChanged(magnification),
+      () => this.fontController.unitsPerEm
     );
     this.canvasController = canvasController;
 

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -122,10 +122,8 @@ export class EditorController extends ViewController {
     canvas.ondragleave = (event) => this._onDragLeave(event);
     canvas.ondrop = (event) => this._onDrop(event);
 
-    const canvasController = new CanvasController(
-      canvas,
-      (magnification) => this.canvasMagnificationChanged(magnification),
-      () => this.fontController.unitsPerEm
+    const canvasController = new CanvasController(canvas, (magnification) =>
+      this.canvasMagnificationChanged(magnification)
     );
     this.canvasController = canvasController;
 

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -65,6 +65,23 @@ import { dialog, message } from "@fontra/web-components/modal-dialog.js";
 import { EditBehaviorFactory } from "./edit-behavior.js";
 import { SceneModel } from "./scene-model.js";
 
+// Minimum pixels per em and maximum pixels per unit for zooming out and in.
+//
+// Note that these are not _screen pixels_, they are css "pixels" which are
+// scaled by screen DPI and browser zoom level. So on a high dpi display or
+// in a browser with a higher zoom level set, the minimum and maximum scale
+// in _screen pixels_ will be higher (for both).
+//
+// Zooming out is capped by pixels per em to allow a consistent size when
+// zoomed all the way out at different em scales, and zooming in is capped
+// by pixels per unit to allow a consistent 1 unit size when zoomed all the
+// way in regardless of em scale.
+//
+// These values are chosen arbitrarily and in the future there may
+// be some merit to letting users configure this to their own taste.
+const MIN_PIX_PER_EM = 5;
+const MAX_PIX_PER_UNIT = 200;
+
 export class SceneController {
   constructor(
     fontController,
@@ -123,6 +140,7 @@ export class SceneController {
         { sentFromInitializer: true }
       );
       this.updateShaperInfo();
+      this.setCanvasMagnificationLimits();
     });
 
     // Set up the mutual relationship between text and characterLines
@@ -349,6 +367,22 @@ export class SceneController {
     this.fontController.addChangeListener({ glyphMap: null }, (change) =>
       updateCombinedGlyphAndCharacterMapping(null, change)
     );
+
+    this.fontController.addChangeListener({ unitsPerEm: null }, (change) =>
+      this.setCanvasMagnificationLimits()
+    );
+  }
+
+  setCanvasMagnificationLimits() {
+    // The lower magnification limit is implemented relative to UPM
+    // to provide a consistent em size when zoomed all the way out.
+    this.canvasController.minMagnification =
+      MIN_PIX_PER_EM / this.fontController.unitsPerEm;
+
+    // The upper magnification limit is implemented relative to individual
+    // units, so that when zoomed all the way in the size of an individual
+    // unit is the same regardless of em size.
+    this.canvasController.maxMagnification = MAX_PIX_PER_UNIT;
   }
 
   async updateCombinedGlyphAndCharacterMapping(event, change) {


### PR DESCRIPTION
Closes #2573 

I'm not sure whether you'll be okay with how I chose to implement this. I went with the way that gave the smallest set of changes, but it does slightly muddle the responsibilities of the `CanvasController` by making it aware of the UPM, and the way it's provided that info is by being passed a function (rather than having other parts of the code call *in* to it to update it on the current UPM whenever that changes, or having it be completely unaware of UPM and have someone else calculate and update the magnification limits for it whenever the UPM changes).