### PR TITLE
Selectable text size

### DIFF
--- a/src-js/views-editor/src/panel-text-entry.js
+++ b/src-js/views-editor/src/panel-text-entry.js
@@ -9,6 +9,7 @@ import {
   Accordion,
   makeAccordionHeaderButton,
 } from "@fontra/web-components/ui-accordion.js";
+import { Form } from "@fontra/web-components/ui-form.js";
 import Panel from "./panel.js";
 
 // These features are on by default. See hb-ot-shape.cc
@@ -179,6 +180,7 @@ export default class TextEntryPanel extends Panel {
 
     this.setupTextEntryElement();
     this.setupTextAlignElement();
+    this.setupTextSizeElement();
     this.setupAccordionElement();
     this.setupIntersectionObserver();
   }
@@ -219,6 +221,7 @@ export default class TextEntryPanel extends Panel {
                 }),
               ]
             ),
+            html.div({ id: "text-size-menu" }),
             html.div({ id: "text-settings-accordion" }),
           ]
         ),
@@ -324,6 +327,68 @@ export default class TextEntryPanel extends Panel {
         this.textSettings.align = el.dataset.align;
       };
     }
+  }
+
+  setupTextSizeElement() {
+    this.textSizeForm = new Form();
+    this.textSizeForm.id = "text-size-menu";
+    this.textSizeForm.labelWidth = "max-content";
+
+    this.textSizeForm.onFieldChange = async (fieldItem, value, valueStream) => {
+      switch (fieldItem.key) {
+        case "size":
+          {
+            this.textSettingsController.setItem("textSize", value, this);
+          }
+          break;
+      }
+    };
+
+    this.textSettingsController.addKeyListener(
+      "textSize",
+      (event) => {
+        this.textSizeForm.setValue("size", this.textSettings.textSize);
+      },
+      false
+    );
+
+    const formContents = [];
+
+    formContents.push({
+      type: "edit-number",
+      key: "size",
+      label: "Text size", // TODO: translate
+      value: this.textSettings.textSize,
+      minValue: 1,
+      integer: false,
+      numDigits: 2,
+      evaluateExpression: async (expression) =>
+        this._evaluateTextSizeExpression(expression),
+    });
+
+    this.textSizeForm.setFieldDescriptions(formContents);
+
+    const placeHolder = this.contentElement.querySelector("#text-size-menu");
+    placeHolder.replaceWith(this.textSizeForm);
+  }
+
+  _evaluateTextSizeExpression(expression) {
+    const value = parseInt(expression, 10);
+
+    // Invalid (empty or unparseable) input, default to the current size.
+    if (isNaN(value)) {
+      return this.textSettings.textSize;
+    }
+
+    const lc = expression.toLowerCase();
+
+    // Lower case ends with "px", convert to points to set the value.
+    if (lc.endsWith("px")) {
+      return value / window.devicePixelRatio;
+    }
+
+    // None of our special cases match, assume it's just points.
+    return value;
   }
 
   setupTextEntryElement() {

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -338,7 +338,47 @@ export class SceneController {
         this.canvasController.getViewBox(),
         { senderID: this }
       );
+
+      this.fontController.ensureInitialized.then(() => {
+        this.sceneSettingsController.setItem(
+          "textSize",
+          this.canvasController.magnification * this.fontController.unitsPerEm,
+          { senderID: this }
+        );
+      });
     });
+
+    this.sceneSettingsController.addKeyListener(
+      "textSize",
+      (event) => {
+        if (event.senderInfo?.senderID === this) {
+          return;
+        }
+        if (!event.newValue) {
+          // Ignore null-ish
+          return;
+        }
+
+        // Clamp magnification value to appropriate range
+        // and update canvas controller with the new value.
+        this.canvasController.magnification = Math.min(
+          Math.max(
+            event.newValue / this.fontController.unitsPerEm,
+            this.canvasController.minMagnification
+          ),
+          this.canvasController.maxMagnification
+        );
+        this.canvasController.requestUpdate();
+
+        // Set the text size value back since it might have been clamped.
+        this.sceneSettingsController.setItem(
+          "textSize",
+          this.canvasController.magnification * this.fontController.unitsPerEm,
+          { senderID: this }
+        );
+      },
+      true
+    );
 
     // Update background layer glyphs
     this.sceneSettingsController.addKeyListener(
@@ -1840,6 +1880,7 @@ export const persistentSceneSettingsKeys = persistentSceneSettings.map(
 function getSceneSettingsDefaults() {
   return {
     text: "",
+    textSize: null,
     align: "center",
     editLayerName: null,
     characterLines: [],


### PR DESCRIPTION
This is implemented on top of #2574 so had its commits in it-- I believe the GitHub UI will update it appropriately for better review once the other PR is merged.

This is a first pass at #105 -- it adds two inputs to the text entry panel, one for setting the text size in points and the other for setting it in pixels.

These values automatically update as the user zooms in other ways, and when modified by the user they directly change the magnification value of the canvas, which I'm sure is the wrong way to go about it, and can be a little jarring because it's not animated at all.

The UI also isn't very pretty. This is why I called it a "first pass", since it needs cleaning up, but I think the foundation of having live display of the current size in pt and px that can be updated by the user to zoom to that level is good.

https://github.com/user-attachments/assets/eabd61dd-9153-41b2-82ee-258264fe708d