### PR TITLE
Add a whole bunch of JSDoc type annotations

### DIFF
--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,21 +1,36 @@
 import { normalizeRect, rectCenter, validateRect } from "./rectangle.js";
 import { assert, clamp, consolidateCalls, isNumber, withSavedState } from "./utils.js";
 
+/** @import { Rectangle } from "./rectangle.js" */
+/** @import { SceneView } from "./scene-view.js" */
+
 const DEFAULT_MIN_MAGNIFICATION = 0.005;
 const DEFAULT_MAX_MAGNIFICATION = 200;
 
 export class CanvasController {
+  /**
+   * @param {HTMLCanvasElement} canvas
+   * @param {undefined | (number) => void} magnificationChangedCallback
+   */
   constructor(canvas, magnificationChangedCallback) {
+    /** @type {HTMLCanvasElement} */
     this.canvas = canvas; // The HTML5 Canvas object
+    /** @type {CanvasRenderingContext2D} */
     this.context = canvas.getContext("2d");
+    /** @type {SceneView} */
     this.sceneView = undefined; // will be set later
 
+    /** @type {number} */
     this.magnification = 1;
+    /** @type {{ x: number, y: number }} */
     this.origin = { x: this.canvasWidth / 2, y: 0.85 * this.canvasHeight }; // TODO choose y based on initial canvas height
 
+    /** @type {number} */
     this._minMagnification = DEFAULT_MIN_MAGNIFICATION;
+    /** @type {number} */
     this._maxMagnification = DEFAULT_MAX_MAGNIFICATION;
 
+    /** @type {undefined | (number) => void} */
     this._magnificationChangedCallback = magnificationChangedCallback;
 
     const resizeObserver = new ResizeObserver((entries) => {
@@ -317,6 +332,7 @@ export class CanvasController {
     return 1 / this.magnification;
   }
 
+  /** @returns {Rectangle} */
   getViewBox() {
     const width = this.canvasWidth;
     const height = this.canvasHeight;
@@ -334,6 +350,7 @@ export class CanvasController {
     return viewBox;
   }
 
+  /** @param {Rectangle} viewBox */
   isActualViewBox(viewBox) {
     const canvasCenter = this.canvasPoint(rectCenter(viewBox));
     return (
@@ -345,6 +362,7 @@ export class CanvasController {
     );
   }
 
+  /** @param {Rectangle} viewBox */
   setViewBox(viewBox) {
     validateRect(viewBox);
     this.magnification = this._getProposedViewBoxMagnification(viewBox);
@@ -356,6 +374,7 @@ export class CanvasController {
     this._dispatchEvent("viewBoxChanged", "set-view-box");
   }
 
+  /** @param {Rectangle} viewBox */
   getProposedViewBoxClampAdjustment(viewBox) {
     const magnification = this._getProposedViewBoxMagnification(viewBox);
     if (magnification < this.minMagnification) {
@@ -366,6 +385,7 @@ export class CanvasController {
     return 1;
   }
 
+  /** @param {Rectangle} viewBox */
   _getProposedViewBoxMagnification(viewBox) {
     validateRect(viewBox);
     const width = this.canvasWidth;
@@ -377,6 +397,7 @@ export class CanvasController {
     return Math.min(magnificationX, magnificationY);
   }
 
+  /** @param {string} eventName */
   _dispatchEvent(eventName, detail) {
     const event = new CustomEvent(eventName, {
       bubbles: false,

--- a/src-js/fontra-core/src/font-controller.js
+++ b/src-js/fontra-core/src/font-controller.js
@@ -41,7 +41,7 @@ import {
   mapForward,
 } from "./var-model.js";
 /**
- * @import { RemoteFont, FontSource } from 'remotefont';
+ * @import { RemoteFont, FontSource } from "remotefont";
  * */
 
 const GLYPH_CACHE_SIZE = 2000;

--- a/src-js/fontra-core/src/observable-object.js
+++ b/src-js/fontra-core/src/observable-object.js
@@ -2,22 +2,40 @@ import { assert, chain } from "./utils.js";
 
 export const controllerKey = Symbol("controller-key");
 
+/** @template T */
 export class ObservableController {
+  /**
+   * @typedef {{
+   *   key: string,
+   *   newValue: T[key],
+   *   oldValue: T[key],
+   *   senderInfo: any,
+   * }} Event
+   */
+
+  /** @typedef {(event: Event) => void} Listener */
+
+  /** @param {T} model */
   constructor(model) {
     if (!model) {
       model = {};
     }
+    /** @type {T} */
     this.model = newModelProxy(this, model);
     this._rawModel = model;
+    /** @type {Listener[]} */
     this._generalListeners = [];
+    /** @type {Record<string, Listener>} */
     this._keyListeners = {};
     this._senderInfoStack = [];
   }
 
+  /** @param {Listener} listener */
   addListener(listener, immediate = false) {
     this._generalListeners.push({ listener, immediate });
   }
 
+  /** @param {Listener} listener */
   removeListener(listener) {
     // Instead of using indexOf, we use filter, to ensure we also delete any duplicates
     this._generalListeners = this._generalListeners.filter(
@@ -25,6 +43,10 @@ export class ObservableController {
     );
   }
 
+  /**
+   * @param {string | string[]} keyOrKeys
+   * @param {Listener} listener
+   */
   addKeyListener(keyOrKeys, listener, immediate = false) {
     if (typeof keyOrKeys === "string") {
       keyOrKeys = [keyOrKeys];
@@ -37,6 +59,10 @@ export class ObservableController {
     }
   }
 
+  /**
+   * @param {string | string[]} keyOrKeys
+   * @param {Listener} listener
+   */
   removeKeyListener(keyOrKeys, listener) {
     if (typeof keyOrKeys === "string") {
       keyOrKeys = [keyOrKeys];
@@ -52,6 +78,11 @@ export class ObservableController {
     }
   }
 
+  /**
+   * @param {string} key
+   * @param {T[key]} newValue
+   * @param {any} senderInfo
+   */
   setItem(key, newValue, senderInfo) {
     const oldValue = this._rawModel[key];
     if (newValue !== oldValue) {
@@ -68,6 +99,7 @@ export class ObservableController {
     );
   }
 
+  /** @param {string | string[]} keyOrKeys */
   waitForKeyChange(keyOrKeys, immediate = false) {
     let resolvePromise;
 

--- a/src-js/fontra-core/src/rectangle.js
+++ b/src-js/fontra-core/src/rectangle.js
@@ -1,5 +1,22 @@
 import { isNumber } from "./utils.js";
 
+/** @typedef {{
+ * x: number,
+ * y: number,
+ * }} Point */
+
+/** @typedef {{
+ * xMin: number,
+ * yMin: number,
+ * xMax: number,
+ * yMax: number
+ * }} Rectangle */
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {Rectangle} rect
+ */
 export function pointInRect(x, y, rect) {
   if (!rect) {
     return false;
@@ -7,6 +24,12 @@ export function pointInRect(x, y, rect) {
   return x >= rect.xMin && x <= rect.xMax && y >= rect.yMin && y <= rect.yMax;
 }
 
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ */
 export function centeredRect(x, y, width, height) {
   if (height === undefined) {
     height = width;
@@ -21,6 +44,7 @@ export function centeredRect(x, y, width, height) {
   };
 }
 
+/** @param {Rectangle} rect */
 export function normalizeRect(rect) {
   const nRect = {
     xMin: Math.min(rect.xMin, rect.xMax),
@@ -31,17 +55,18 @@ export function normalizeRect(rect) {
   return nRect;
 }
 
+/**
+ * Test for rectangle-rectangle intersection.
+ *
+ * @param {Rectangle} rect1 First bounding rectangle
+ * @param {Rectangle} rect2 Second bounding rectangle
+ *
+ * @returns {Rectangle | undefined} A rectangle or `undefined`.
+ *
+ * If the input rectangles intersect, returns the intersecting rectangle.
+ * Returns ``undefined`` if the input rectangles do not intersect.
+ */
 export function sectRect(rect1, rect2) {
-  // Test for rectangle-rectangle intersection.
-
-  // Args:
-  //     rect1: First bounding rectangle
-  //     rect2: Second bounding rectangle
-
-  // Returns:
-  //     A rectangle or undefined.
-  //     If the input rectangles intersect, returns the intersecting rectangle.
-  //     Returns ``undefined`` if the input rectangles do not intersect.
   const xMin = Math.max(rect1.xMin, rect2.xMin);
   const yMin = Math.max(rect1.yMin, rect2.yMin);
   const xMax = Math.min(rect1.xMax, rect2.xMax);
@@ -52,6 +77,15 @@ export function sectRect(rect1, rect2) {
   return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
 }
 
+/**
+ * Compute the bounding rectangle for all provided rectangles
+ *
+ * @param {Rectangle[]} rectangles
+ *
+ * @returns {Rectangle | undefined} A rectangle or `undefined`.
+ *
+ * If no rectangles are provided, return `undefined`.
+ */
 export function unionRect(...rectangles) {
   if (!rectangles.length) {
     return undefined;
@@ -71,6 +105,11 @@ export function unionRect(...rectangles) {
   return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
 }
 
+/**
+ * @param {Rectangle} rect
+ * @param {number} x
+ * @param {number} y
+ */
 export function offsetRect(rect, x, y) {
   return {
     xMin: rect.xMin + x,
@@ -80,6 +119,11 @@ export function offsetRect(rect, x, y) {
   };
 }
 
+/**
+ * @param {Rectangle} rect
+ * @param {number} sx
+ * @param {number} sy
+ */
 export function scaleRect(rect, sx, sy) {
   if (sy === undefined) {
     sy = sx;
@@ -92,6 +136,11 @@ export function scaleRect(rect, sx, sy) {
   };
 }
 
+/**
+ * @param {Rectangle} rect
+ * @param {number} dx
+ * @param {number} dy
+ */
 export function insetRect(rect, dx, dy) {
   return {
     xMin: rect.xMin + dx,
@@ -101,6 +150,10 @@ export function insetRect(rect, dx, dy) {
   };
 }
 
+/**
+ * @param {Rectangle} rect1
+ * @param {Rectangle} rect2
+ */
 export function equalRect(rect1, rect2) {
   return (
     rect1.xMin === rect2.xMin &&
@@ -110,10 +163,16 @@ export function equalRect(rect1, rect2) {
   );
 }
 
+/**
+ * @param {Rectangle} rect
+ *
+ * @returns {Point}
+ */
 export function rectCenter(rect) {
   return { x: (rect.xMin + rect.xMax) / 2, y: (rect.yMin + rect.yMax) / 2 };
 }
 
+/** @param {Rectangle} rect */
 export function rectSize(rect) {
   return {
     width: Math.abs(rect.xMax - rect.xMin),
@@ -121,6 +180,11 @@ export function rectSize(rect) {
   };
 }
 
+/**
+ * @param {[number, number, number, number]} array
+ *
+ * @returns {Rectangle}
+ */
 export function rectFromArray(array) {
   if (array.length != 4) {
     throw new Error("rect array must have length == 4");
@@ -128,15 +192,26 @@ export function rectFromArray(array) {
   return { xMin: array[0], yMin: array[1], xMax: array[2], yMax: array[3] };
 }
 
+/**
+ * @param {Rectangle} rect
+ *
+ * @returns {[number, number, number, number]}
+ */
 export function rectToArray(rect) {
   return [rect.xMin, rect.yMin, rect.xMax, rect.yMax];
 }
 
+/** @param {Rectangle} rect */
 export function isEmptyRect(rect) {
   const size = rectSize(rect);
   return size.width === 0 && size.height === 0;
 }
 
+/**
+ * @param {Point[]} points
+ *
+ * @returns {Rectangle | undefined}
+ */
 export function rectFromPoints(points) {
   if (!points.length) {
     return undefined;
@@ -155,6 +230,11 @@ export function rectFromPoints(points) {
   return { xMin, yMin, xMax, yMax };
 }
 
+/**
+ * @param {Rectangle} rect
+ *
+ * @returns {[Point, Point, Point, Point]}
+ */
 export function rectToPoints(rect) {
   return [
     { x: rect.xMin, y: rect.yMin },
@@ -164,8 +244,14 @@ export function rectToPoints(rect) {
   ];
 }
 
+/**
+ * @param {Rectangle} rect
+ * @param {Point} point
+ *
+ * @returns {Rectangle}
+ * Return the smallest rect that includes the original rect and the given point
+ */
 export function updateRect(rect, point) {
-  // Return the smallest rect that includes the original rect and the given point
   return {
     xMin: Math.min(rect.xMin, point.x),
     yMin: Math.min(rect.yMin, point.y),
@@ -174,6 +260,12 @@ export function updateRect(rect, point) {
   };
 }
 
+/**
+ * @param {Rectangle} rect
+ * @param {number} relativeMargin
+ *
+ * @returns {Rectangle}
+ */
 export function rectAddMargin(rect, relativeMargin) {
   const size = rectSize(rect);
   const inset =
@@ -183,6 +275,13 @@ export function rectAddMargin(rect, relativeMargin) {
   return insetRect(rect, -inset, -inset);
 }
 
+/**
+ * @param {Rectangle} rect
+ * @param {number} scaleFactor
+ * @param {Point} center
+ *
+ * @returns {Rectangle}
+ */
 export function rectScaleAroundCenter(rect, scaleFactor, center) {
   rect = offsetRect(rect, -center.x, -center.y);
   rect = scaleRect(rect, scaleFactor);
@@ -190,6 +289,11 @@ export function rectScaleAroundCenter(rect, scaleFactor, center) {
   return rect;
 }
 
+/**
+ * @param {Rectangle} rect
+ *
+ * @returns {Rectangle}
+ */
 export function rectRound(rect) {
   return {
     xMin: Math.round(rect.xMin),
@@ -199,6 +303,7 @@ export function rectRound(rect) {
   };
 }
 
+/** @param {Rectangle} rect */
 export function validateRect(rect) {
   if (
     !rect ||

--- a/src-js/fontra-core/src/shaper-controller.js
+++ b/src-js/fontra-core/src/shaper-controller.js
@@ -104,6 +104,7 @@ export class ShaperController {
 
       if (textShaping && fontData) {
         // The new shaper is good
+        /** @type {ReturnType<getShaper>} */
         this._previousShaper = shaper;
       }
 

--- a/src-js/fontra-core/src/utils.js
+++ b/src-js/fontra-core/src/utils.js
@@ -189,6 +189,13 @@ export function* range(start, stop, step = 1) {
   }
 }
 
+/**
+ * @template T
+ *
+ * @param {Iterable<T>[]} iterables
+ *
+ * @returns {Generator<T>}
+ */
 export function* chain(...iterables) {
   // After Python's itertools.chain()
   for (const iterable of iterables) {

--- a/src-js/fontra-core/src/view-controller.js
+++ b/src-js/fontra-core/src/view-controller.js
@@ -7,6 +7,8 @@ import { RemoteError } from "./errors.js";
 import { FontController } from "./font-controller.js";
 import { getRemoteProxy } from "./remote.js";
 
+/** @import { RemoteFont } from "remotefont" */
+
 export class ViewController {
   static titlePattern(displayName) {
     return `Fontra — ${displayName}`;
@@ -44,8 +46,14 @@ export class ViewController {
     return controller;
   }
 
+  /**
+   * @param {RemoteFont} font
+   * @param {string} projectIdentifier
+   */
   constructor(font, projectIdentifier) {
+    /** @type {FontController} */
     this.fontController = new FontController(font);
+    /** @type {string} */
     this.projectIdentifier = projectIdentifier;
 
     document.addEventListener("visibilitychange", (event) => {

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -125,17 +125,20 @@ export class EditorController extends ViewController {
     const canvasController = new CanvasController(canvas, (magnification) =>
       this.canvasMagnificationChanged(magnification)
     );
+    /** @type {CanvasController} */
     this.canvasController = canvasController;
 
     this.fontController.addEditListener(
       async (...args) => await this.editListenerCallback(...args)
     );
 
+    /** @type {VisualizationLayers} */
     this.visualizationLayers = new VisualizationLayers(
       visualizationLayerDefinitions,
       this.isThemeDark
     );
 
+    /** @type {ObservableController<VisualizationLayers>} */
     this.visualizationLayersSettings = newVisualizationLayersSettings(
       this.visualizationLayers
     );
@@ -144,6 +147,7 @@ export class EditorController extends ViewController {
       this.canvasController.requestUpdate();
     }, true);
 
+    /** @type {SceneController} */
     this.sceneController = new SceneController(
       this.fontController,
       canvasController,
@@ -151,6 +155,7 @@ export class EditorController extends ViewController {
       this.visualizationLayersSettings
     );
 
+    /** @type {typeof this.sceneController.sceneSettingsController} */
     this.sceneSettingsController = this.sceneController.sceneSettingsController;
     this.sceneSettings = this.sceneSettingsController.model;
     this.sceneModel = this.sceneController.sceneModel;
@@ -164,6 +169,7 @@ export class EditorController extends ViewController {
       }
     );
 
+    /** @type {CJKDesignFrame} */
     this.cjkDesignFrame = new CJKDesignFrame(this);
 
     const sceneView = new SceneView(this.sceneModel, (model, controller) =>
@@ -173,12 +179,15 @@ export class EditorController extends ViewController {
     );
     canvasController.sceneView = sceneView;
 
+    /** @type {SceneView} */
     this.defaultSceneView = sceneView;
 
+    /** @type {VisualizationLayers} */
     this.cleanGlyphsLayers = new VisualizationLayers(
       [allGlyphsCleanVisualizationLayerDefinition],
       this.isThemeDark
     );
+    /** @type {SceneView} */
     this.cleanSceneView = new SceneView(this.sceneModel, (model, controller) => {
       this.cleanGlyphsLayers.drawVisualizationLayers(
         new VisualizationContext(model, controller)
@@ -3493,6 +3502,7 @@ function matchEvent(handlerDef, event) {
   return true;
 }
 
+/** @returns {ObservableController<VisualizationLayers>} visualizationLayers */
 function newVisualizationLayersSettings(visualizationLayers) {
   const settings = [];
   for (const definition of visualizationLayers.definitions) {

--- a/src-js/views-editor/src/panel-text-entry.js
+++ b/src-js/views-editor/src/panel-text-entry.js
@@ -168,8 +168,11 @@ export default class TextEntryPanel extends Panel {
   constructor(editorController) {
     super(editorController);
 
+    /** @type {typeof this.editorController.sceneSettingsController} */
     this.textSettingsController = this.editorController.sceneSettingsController;
+    /** @type {typeof this.editorController.sceneController} */
     this.sceneController = this.editorController.sceneController;
+    /** @type {typeof this.editorController.sceneSettingsController.model} */
     this.textSettings = this.editorController.sceneSettingsController.model;
 
     this.textSettingsController.addKeyListener(

--- a/src-js/views-editor/src/panel.js
+++ b/src-js/views-editor/src/panel.js
@@ -1,5 +1,8 @@
 import { SimpleElement } from "@fontra/core/html-utils.js";
 
+/** @import { EditorController } from "@fontra/views-editor/editor.js" */
+/** @import { FontController } from "@fontra/core/font-controller.js" */
+
 export default class Panel extends SimpleElement {
   panelStyles = `
     .panel {
@@ -34,9 +37,12 @@ export default class Panel extends SimpleElement {
 
   constructor(editorController) {
     super();
+    /** @type {EditorController} */
     this.editorController = editorController;
+    /** @type {FontController} */
     this.fontController = editorController.fontController;
     this._appendStyle(this.panelStyles);
+    /** @type {Element} */
     this.contentElement = this.getContentElement();
     this.shadowRoot.appendChild(this.contentElement);
   }

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -65,6 +65,14 @@ import { dialog, message } from "@fontra/web-components/modal-dialog.js";
 import { EditBehaviorFactory } from "./edit-behavior.js";
 import { SceneModel } from "./scene-model.js";
 
+/** @import { Rectangle } from "@fontra/core/rectangle.js" */
+/** @import { FontController } from "@fontra/core/font-controller.js" */
+/** @import { CanvasController } from "@fontra/core/canvas-controller.js" */
+/** @import { applicationSettingsController } from "@fontra/core/application-settings.js" */
+/** @import { getShaper } from "@fontra/core/shaper.js" */
+
+/** @typedef {ReturnType<typeof getSceneSettingsDefaults>} SceneSettings */
+
 // Minimum pixels per em and maximum pixels per unit for zooming out and in.
 //
 // Note that these are not _screen pixels_, they are css "pixels" which are
@@ -83,14 +91,23 @@ const MIN_PIX_PER_EM = 5;
 const MAX_PIX_PER_UNIT = 200;
 
 export class SceneController {
+  /**
+   * @param {FontController} fontController
+   * @param {CanvasController} canvasController
+   * @param {typeof applicationSettingsController} applicationSettingsController
+   * @param {} visualizationLayersSettings
+   */
   constructor(
     fontController,
     canvasController,
     applicationSettingsController,
     visualizationLayersSettings
   ) {
+    /** @type {CanvasController} */
     this.canvasController = canvasController;
+    /** @type {typeof applicationSettingsController} */
     this.applicationSettings = applicationSettingsController.model;
+    /** @type {FontController} */
     this.fontController = fontController;
     this.autoViewBox = true;
 
@@ -103,6 +120,7 @@ export class SceneController {
       canvasController.context
     );
 
+    /** @type {SceneModel} */
     this.sceneModel = new SceneModel(
       fontController,
       this.sceneSettingsController,
@@ -127,7 +145,9 @@ export class SceneController {
   }
 
   setupSceneSettings() {
+    /** @type {ObservableController<SceneSettings>} */
     this.sceneSettingsController = new ObservableController(getSceneSettingsDefaults());
+    /** @type {SceneSettings} */
     this.sceneSettings = this.sceneSettingsController.model;
 
     this.sceneSettings.viewBox = this.canvasController.getViewBox();
@@ -1841,7 +1861,9 @@ function getSceneSettingsDefaults() {
   return {
     text: "",
     align: "center",
+    /** @type {string?} */
     editLayerName: null,
+    /** @type {ReturnType<typeof characterLinesFromString>} */
     characterLines: [],
     fontLocationUser: {},
     fontLocationSource: {},
@@ -1851,12 +1873,16 @@ function getSceneSettingsDefaults() {
     fontAxesShowHidden: false,
     fontAxesSkipMapping: false,
     glyphLocation: {},
+    /** @type {Glyph?} */
     selectedGlyph: null,
+    /** @type {string?} */
     selectedGlyphName: null,
+    /** @type {string?} */
     substituteGlyphName: null,
     selection: new Set(),
     hoverSelection: new Set(),
     combinedSelection: new Set(), // dynamic: selection | hoverSelection
+    /** @type {Rectangle?} */
     viewBox: null,
     positionedLines: [],
     backgroundImagesAreLocked: true,
@@ -1864,11 +1890,17 @@ function getSceneSettingsDefaults() {
     editingLayers: {},
     featureSettings: {},
     applyTextShaping: true,
+    /** @type {string?} */
     textDirection: null,
+    /** @type {string?} */
     textScript: null,
+    /** @type {string?} */
     textLanguage: null,
+    /** @type {ReturnType<typeof getShaper>?} */
     shaper: null,
+    /** @type {ReturnType<InstanceType<typeof ShaperController>["getShaper"]>?} */
     shaperInfo: null,
+    /** @type {ReturnType<InstanceType<typeof ShaperController>["getShaper"]>?} */
     dumbShaperInfo: null,
     glyphRenderInfoLineIndex: 0,
     shapingDebuggerEnabled: false,

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -36,6 +36,9 @@ import {
 import { normalizeLocation, unnormalizeLocation } from "@fontra/core/var-model.js";
 import * as vector from "@fontra/core/vector.js";
 
+/** @import { ObservableController } from "@fontra/core/observable-object.js" */
+/** @import { Rectangle } from "@fontra/core/rectangle.js" */
+
 export class SceneModel {
   constructor(
     fontController,
@@ -43,7 +46,9 @@ export class SceneModel {
     isPointInPath,
     visualizationLayersSettings
   ) {
+    /** @type {FontController} */
     this.fontController = fontController;
+    /** @type {ObservableController<SceneSettings>} */
     this.sceneSettingsController = sceneSettingsController;
     this.sceneSettings = sceneSettingsController.model;
     this.isPointInPath = isPointInPath;
@@ -54,6 +59,8 @@ export class SceneModel {
     this.usedGlyphNames = new Set();
     this.cachedGlyphNames = new Set();
     this.updateSceneCancelSignal = {};
+    /** @type {Rectangle | undefined} */
+    this.selectionRect = undefined;
 
     this.sceneSettingsController.addKeyListener(
       [
@@ -1266,6 +1273,24 @@ function sorted(v) {
   v.sort((a, b) => a - b);
   return v;
 }
+
+/**
+ * @typedef {{
+ *   x: number,
+ *   y: number,
+ *   kernValue: number,
+ *   glyph: any,
+ *   varGlyph: any,
+ *   glyphName: string,
+ *   character: string,
+ *   cluster: any,
+ *   isUndefined: boolean,
+ *   isSelected: boolean,
+ *   isEditing: boolean,
+ *   isEmpty: boolean,
+ *   glyphInfo: any
+ * }} PositionedGlyph
+ */
 
 class LineSetter {
   constructor(

--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -16,8 +16,52 @@ import {
 } from "@fontra/core/utils.js";
 import { subVectors } from "@fontra/core/vector.js";
 
+/** @import { CanvasController } from "@fontra/core/canvas-controller.js" */
+/** @import { SceneModel, PositionedGlyph } from "./scene-model.js" */
+
+/**
+ * @template [ScreenParams = unknown]
+ * @template [GlyphParams = unknown]
+ * @template [Colors = unknown]
+ * @template [ColorsDarkMode = unknown]
+ *
+ * @typedef {{
+ *   identifier: string,
+ *   name: string,
+ *   selectionFunc?: Function,
+ *   selectionFilter?: Function,
+ *   userSwitchable?: boolean,
+ *   defaultOn?: boolean,
+ *   zIndex: number,
+ *   dontTranslate?: boolean,
+ *   screenParameters?: ScreenParams,
+ *   glyphParameters?: GlyphParams,
+ *   colors?: Colors,
+ *   colorsDarkMode?: ColorsDarkMode,
+ *   draw: (
+ *     context: CanvasRenderingContext2D,
+ *     positionedGlyph: PositionedGlyph,
+ *     parameters: ScreenParams
+ *               & GlyphParams
+ *               & Colors
+ *               & ColorsDarkMode,
+ *     model: SceneModel,
+ *     controller: CanvasController,
+ *   ) => void,
+ * }} VisualizationLayerDefinition
+ */
+
+/** @type {VisualizationLayerDefinition[]} */
 export const visualizationLayerDefinitions = [];
 
+/**
+ * @template [A = unknown]
+ * @template [B = unknown]
+ * @template [C = unknown]
+ * @template [D = unknown]
+ *
+ * @param {VisualizationLayerDefinition<A,B,C,D>} newLayerDef
+ */
 export function registerVisualizationLayerDefinition(newLayerDef) {
   let index = 0;
   let layerDef;


### PR DESCRIPTION
I just sorta walked around the parts of the codebase I've been working with and checked whether my editor was resolving the types on important things (areas with a lot of indirection mainly), and whenever it wasn't resolving them I added annotations until it could.

Some annotations are incomplete- with fields typed as `any` instead of a more specific type, because I didn't want to go down the rabbit hole for that type.

These annotations do make the touched sections of the code a lot nicer to work in in editors with appropriate tooling, since going to definitions is made easier and completions for properties and methods ... exist.

If you have any questions or concerns feel free to ask.