### PR TITLE
Add blog and Discord links to fontra-menus

### DIFF
--- a/src-js/fontra-core/src/fontra-menus.js
+++ b/src-js/fontra-core/src/fontra-menus.js
@@ -101,12 +101,14 @@ function getHelpMenu() {
           callback: () => {
             window.open("https://github.com/fontra", "fontra.github");
           },
+        },
         {
           title: "Blog",
           enabled: () => true,
           callback: () => {
             window.open("https://blog.fontra.xyz", "fontra.blog");
           },
+        },
         {
           title: "Discord",
           enabled: () => true,

--- a/src-js/fontra-core/src/fontra-menus.js
+++ b/src-js/fontra-core/src/fontra-menus.js
@@ -101,6 +101,18 @@ function getHelpMenu() {
           callback: () => {
             window.open("https://github.com/fontra", "fontra.github");
           },
+        {
+          title: "Blog",
+          enabled: () => true,
+          callback: () => {
+            window.open("https://blog.fontra.xyz", "fontra.blog");
+          },
+        {
+          title: "Discord",
+          enabled: () => true,
+          callback: () => {
+            window.open("https://discord.gg/SeZWugEYzd", "fontra.discord");
+          },
         },
       ];
     },


### PR DESCRIPTION
To match prominent links on the homepage

Possibly this needs 1+ more commits that add the localizations of the menus 