### PR TITLE
[designspace navigation] Move hidden axes to separate section

### DIFF
--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -301,6 +301,8 @@ export const strings = {
     "Achsübergreifendes Mapping anwenden",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Einachsiges Mapping anwenden",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     'effektive "location" anzeigen',
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -301,12 +301,12 @@ export const strings = {
     "Achsübergreifendes Mapping anwenden",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Einachsiges Mapping anwenden",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     'effektive "location" anzeigen',
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "Versteckte Achsen anzeigen",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "Font-Achsen bearbeiten ",
   "sidebar.designspace-navigation.font-axes.reset": "Font-Achsen zurücksetzen",
   "sidebar.designspace-navigation.glyph-axes": "Glyph-Achsen",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -296,12 +296,12 @@ export const strings = {
     "Apply cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Apply single-axis mapping",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "Show hidden axes",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "Edit font axes",
   "sidebar.designspace-navigation.font-axes.reset": "Reset font axes",
   "sidebar.designspace-navigation.glyph-axes": "Glyph axes",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -296,6 +296,8 @@ export const strings = {
     "Apply cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Apply single-axis mapping",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -304,12 +304,12 @@ export const strings = {
     "Apply cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Apply single-axis mapping",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "Monter les axes cachés",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "Éditer les axes de la fonte",
   "sidebar.designspace-navigation.font-axes.reset":
     "Réinitialiser les axes de la fonte",

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -304,6 +304,8 @@ export const strings = {
     "Apply cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Apply single-axis mapping",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -298,6 +298,8 @@ export const strings = {
     "交差補完軸マッピングを適用",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "単一補完軸マッピングを適用",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "有効な補完軸の値を表示",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -298,12 +298,12 @@ export const strings = {
     "交差補完軸マッピングを適用",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "単一補完軸マッピングを適用",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "有効な補完軸の値を表示",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "非表示の補完軸を表示",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "フォントの補完軸を編集",
   "sidebar.designspace-navigation.font-axes.reset": "フォントの補完軸をリセット",
   "sidebar.designspace-navigation.glyph-axes": "グリフの補完軸",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -298,12 +298,12 @@ export const strings = {
     "Apply cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Apply single-axis mapping",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "Show hidden axes",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "Wijzig font assen",
   "sidebar.designspace-navigation.font-axes.reset": "Reset font assen",
   "sidebar.designspace-navigation.glyph-axes": "Glyph assen",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -298,6 +298,8 @@ export const strings = {
     "Apply cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Apply single-axis mapping",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/tl.js
+++ b/src-js/fontra-core/assets/lang/tl.js
@@ -307,6 +307,8 @@ export const strings = {
     "Ilapat ang cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Ilapat ang pagmamapa ng iisang aksis",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Ipakita ang epektibong lokasyon",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/tl.js
+++ b/src-js/fontra-core/assets/lang/tl.js
@@ -307,12 +307,12 @@ export const strings = {
     "Ilapat ang cross-axis mapping",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "Ilapat ang pagmamapa ng iisang aksis",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "Ipakita ang epektibong lokasyon",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "Ipakita ang mga nakatagong axes",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "I-edit ang mga font axes",
   "sidebar.designspace-navigation.font-axes.reset": "I-reset ang mga font axes",
   "sidebar.designspace-navigation.glyph-axes": "Mga palakol ng Glyph",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -282,12 +282,12 @@ export const strings = {
     "应用跨轴映射",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "应用单轴映射",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "显示有效位置",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "显示隐藏参数轴",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "编辑字体参数轴",
   "sidebar.designspace-navigation.font-axes.reset": "重置字体参数轴",
   "sidebar.designspace-navigation.glyph-axes": "字形参数轴",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -282,6 +282,8 @@ export const strings = {
     "应用跨轴映射",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "应用单轴映射",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "显示有效位置",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/zh-TW.js
+++ b/src-js/fontra-core/assets/lang/zh-TW.js
@@ -283,6 +283,8 @@ export const strings = {
     "套用跨軸對應",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "套用單軸對應",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
+    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "顯示有效位置",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":

--- a/src-js/fontra-core/assets/lang/zh-TW.js
+++ b/src-js/fontra-core/assets/lang/zh-TW.js
@@ -283,12 +283,12 @@ export const strings = {
     "套用跨軸對應",
   "sidebar.designspace-navigation.font-axes-view-options-menu.apply-single-axis-mapping":
     "套用單軸對應",
-  "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location":
-    "Only show effective location",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location":
     "顯示有效位置",
   "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes":
     "顯示隱藏參數軸",
+  "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location":
+    "Show only effective location",
   "sidebar.designspace-navigation.font-axes.edit": "編輯字型參數軸",
   "sidebar.designspace-navigation.font-axes.reset": "重設字型參數軸",
   "sidebar.designspace-navigation.glyph-axes": "字形參數軸",

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -11,7 +11,7 @@ export class DesignspaceLocation extends UnlitElement {
   static styles = `
     ${themeColorCSS(colors)}
 
-    :host {
+    .grid-wrapper {
       display: grid;
       grid-template-columns: 25% auto;
       gap: 0.3em;
@@ -162,7 +162,7 @@ export class DesignspaceLocation extends UnlitElement {
       }
       this._setupAxis(elements, axis, phantomAxesByName[axis.name]);
     }
-    return elements;
+    return [html.div({ class: "grid-wrapper" }, elements)];
   }
 
   _setupAxis(elements, axis, phantomAxis) {

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -18,6 +18,10 @@ export class DesignspaceLocation extends UnlitElement {
       overflow: auto;
     }
 
+    .grid-wrapper.only-show-phantom-axes {
+      gap: 0;
+    }
+
     .slider-label {
       text-align: right;
       text-overflow: ellipsis;
@@ -162,7 +166,12 @@ export class DesignspaceLocation extends UnlitElement {
       }
       this._setupAxis(elements, axis, phantomAxesByName[axis.name]);
     }
-    return [html.div({ class: "grid-wrapper" }, elements)];
+
+    const gridWrapper = html.div({ class: "grid-wrapper" }, elements);
+    if (this.onlyShowPhantomAxes) {
+      gridWrapper.classList.add("only-show-phantom-axes");
+    }
+    return [gridWrapper];
   }
 
   _setupAxis(elements, axis, phantomAxis) {

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -12,6 +12,8 @@ export class DesignspaceLocation extends UnlitElement {
     ${themeColorCSS(colors)}
 
     .grid-wrapper {
+      height: 100%;
+      width: 100%;
       display: grid;
       grid-template-columns: 25% auto;
       gap: 0.3em;

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -23,7 +23,6 @@ export class DesignspaceLocation extends UnlitElement {
       text-overflow: ellipsis;
       vertical-align: middle;
       margin-top: 1px;
-      margin-bottom: -0.3em;
     }
 
     .slider-label:hover {

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -36,6 +36,11 @@ export class DesignspaceLocation extends UnlitElement {
       gap: 0.1em;
     }
 
+    .slider-group > .slider-disabled:only-child {
+      height: 1.5em;
+      transform: translate(0, 0.275em);
+    }
+
     .info-box {
       display: none;
       grid-column: 1 / -1;
@@ -220,6 +225,7 @@ export class DesignspaceLocation extends UnlitElement {
         }
       },
       disabled: sliderDisabled,
+      class: sliderDisabled ? "slider-disabled" : "",
     };
     if (axis.values) {
       // Discrete axis

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -20,10 +20,10 @@ export class DesignspaceLocation extends UnlitElement {
 
     .slider-label {
       text-align: right;
-      overflow: hidden; /* this needs to be set so that width respects fit-content */
       text-overflow: ellipsis;
       vertical-align: middle;
       margin-top: 1px;
+      margin-bottom: -0.3em;
     }
 
     .slider-label:hover {
@@ -37,8 +37,7 @@ export class DesignspaceLocation extends UnlitElement {
     }
 
     .slider-group > .slider-disabled:only-child {
-      height: 1.5em;
-      transform: translate(0, 0.275em);
+      transform: translate(0, 0.25em);
     }
 
     .info-box {

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -19,7 +19,7 @@ export class DesignspaceLocation extends UnlitElement {
     }
 
     .grid-wrapper.only-show-phantom-axes {
-      gap: 0;
+      row-gap: 0;
     }
 
     .slider-label {

--- a/src-js/fontra-webcomponents/src/designspace-location.js
+++ b/src-js/fontra-webcomponents/src/designspace-location.js
@@ -68,6 +68,7 @@ export class DesignspaceLocation extends UnlitElement {
   static properties = {
     axes: { type: Array },
     phantomAxes: { type: Array },
+    onlyShowPhantomAxes: { type: Boolean },
   };
 
   get model() {
@@ -183,6 +184,8 @@ export class DesignspaceLocation extends UnlitElement {
         }
       </div>`
     );
+
+    const sliderGroupContents = [];
     elements.push(
       html.div(
         {
@@ -192,9 +195,12 @@ export class DesignspaceLocation extends UnlitElement {
         [axis.name]
       )
     );
-    const slider = this._createSlider(axis, modelValue);
-    this._sliders[axis.name] = slider;
-    const sliderGroupContents = [slider];
+    if (!this.onlyShowPhantomAxes) {
+      const slider = this._createSlider(axis, modelValue);
+      this._sliders[axis.name] = slider;
+      sliderGroupContents.push(slider);
+    }
+
     if (phantomAxis) {
       const phantomSlider = this._createSlider(phantomAxis, phantomModelValue, true);
       this._phantomSliders[axis.name] = phantomSlider;

--- a/src-js/fontra-webcomponents/src/range-slider.js
+++ b/src-js/fontra-webcomponents/src/range-slider.js
@@ -25,20 +25,19 @@ export class RangeSlider extends html.UnlitElement {
 
     .wrapper {
       position: relative;
-      display: flex;
+      display: grid;
+      grid-template-columns: min-content auto;
       gap: 0.5em;
       font-family: fontra-ui-regular, sans-serif;
       font-feature-settings: "tnum" 1;
     }
 
     .wrapper.disabled {
-      height: var(--thumb-height);
       margin-top: -3px;
     }
 
     .range-container {
-      position: relative;
-      flex-grow: 1;
+      padding: 0;
     }
 
     /* Chrome, Safari, Edge, Opera */
@@ -59,12 +58,11 @@ export class RangeSlider extends html.UnlitElement {
       margin: 0;
       width: 100%;
       background: transparent;
-      height: 1rem;
       vertical-align: middle;
     }
 
     .slider:disabled {
-      height: calc(1rem * var(--disabled-factor));
+
     }
 
     /* Special styling for WebKit/Blink */
@@ -145,37 +143,11 @@ export class RangeSlider extends html.UnlitElement {
       z-index: -1;
     }
 
-    .range-container > .range-slider-options {
-      position: relative;
-      padding: 0 10px; // half of var(--thumb-width). Not recognised if referenced by variable
-    }
-
-    .range-container > .range-slider-options > span {
-      display: block;
-      position: relative;
-      left: calc(var(--offset));
-      width: 2px;
-      height: 5.5px;
-      opacity: 0.65;
-      background: dimgray;
-    }
-
     input {
       width: inherit;
     }
 
-    .numeric-input > div {
-      opacity: 0.3;
-      font-size: 1em;
-      padding: 5px;
-      pointer-events: none;
-    }
-
-    .numeric-input > .slider-input {
-      position: relative;
-    }
-
-    .numeric-input > .slider-input > .slider-numeric-input {
+    .numeric-input > .slider-numeric-input {
       width: 40px;
       border-radius: 6px;
 
@@ -185,6 +157,7 @@ export class RangeSlider extends html.UnlitElement {
       color: var(--ui-element-foreground-color);
 
       padding: 2px 3px;
+      margin: 0;
 
       text-align: center;
       font-family: fontra-ui-regular;
@@ -193,10 +166,11 @@ export class RangeSlider extends html.UnlitElement {
       vertical-align: middle;
     }
 
-    .numeric-input > .slider-input > .slider-numeric-input:disabled {
+    .numeric-input > .slider-numeric-input:disabled {
       background-color: unset;
       color: var(--disabled-text-color);
-      padding: 0 3px;
+      padding: 0;
+      margin: 0;
       font-size: 0.8em;
       border-radius: unset;
     }
@@ -399,30 +373,28 @@ export class RangeSlider extends html.UnlitElement {
       },
       [
         html.div({ class: "numeric-input" }, [
-          html.section({ class: "slider-input" }, [
-            (this.numberInput = html.input({
-              disabled: this.disabled,
-              type: "number",
-              class: "slider-numeric-input",
-              value,
-              step: this.step,
-              required: "required",
-              min: this.minValue,
-              max: this.maxValue,
-              pattern: "[0-9]+",
-              onkeydown: (event) => this.onKeyDown(event),
-              onchange: (event) => {
-                const value = this.getValueFromEventTarget(event);
-                this.value = value;
-                const callbackEvent = { value };
-                if (this.sawMouseDown) {
-                  callbackEvent.dragBegin = true;
-                }
-                this.sawMouseDown = false;
-                this.onChangeCallback(callbackEvent);
-              },
-            })),
-          ]),
+          (this.numberInput = html.input({
+            disabled: this.disabled,
+            type: "number",
+            class: "slider-numeric-input",
+            value,
+            step: this.step,
+            required: "required",
+            min: this.minValue,
+            max: this.maxValue,
+            pattern: "[0-9]+",
+            onkeydown: (event) => this.onKeyDown(event),
+            onchange: (event) => {
+              const value = this.getValueFromEventTarget(event);
+              this.value = value;
+              const callbackEvent = { value };
+              if (this.sawMouseDown) {
+                callbackEvent.dragBegin = true;
+              }
+              this.sawMouseDown = false;
+              this.onChangeCallback(callbackEvent);
+            },
+          })),
         ]),
         html.div(
           {

--- a/src-js/fontra-webcomponents/src/range-slider.js
+++ b/src-js/fontra-webcomponents/src/range-slider.js
@@ -8,6 +8,8 @@ const colors = {
   "track-color": ["#ccc", "#222"],
   "disabled-color": ["#ddd", "#2e2e2e"],
   "disabled-text-color": ["#999", "#aaa"],
+  "disabled-thumb-color": ["#888", "#bbb"],
+  "disabled-thumb-color-at-default": ["#ccc", "#777"],
 };
 
 export class RangeSlider extends html.UnlitElement {
@@ -79,13 +81,13 @@ export class RangeSlider extends html.UnlitElement {
 
     .slider:disabled::-webkit-slider-thumb {
       height: calc(var(--thumb-height) * var(--disabled-factor));
-      background: var(--disabled-color);
+      background: var(--disabled-thumb-color);
       cursor: unset;
       margin-top: calc(-4.5px * var(--disabled-factor));
     }
 
     .slider.is-at-default:disabled::-webkit-slider-thumb {
-      background: var(--disabled-color);
+      background: var(--disabled-thumb-color-at-default);
     }
 
     .slider.is-at-default::-webkit-slider-thumb {
@@ -114,7 +116,7 @@ export class RangeSlider extends html.UnlitElement {
 
     .slider:disabled::-moz-range-thumb {
       height: calc(var(--thumb-height) * var(--disabled-factor));
-      background: var(--disabled-color);
+      background: var(--disabled-thumb-color);
       cursor: unset;
     }
 
@@ -123,7 +125,7 @@ export class RangeSlider extends html.UnlitElement {
     }
 
     .slider.is-at-default:disabled::-moz-range-thumb {
-      background: var(--disabled-color);
+      background: var(--disabled-thumb-color-at-default);
     }
 
     .slider::-moz-range-track {

--- a/src-js/fontra-webcomponents/src/range-slider.js
+++ b/src-js/fontra-webcomponents/src/range-slider.js
@@ -6,10 +6,10 @@ const colors = {
   "thumb-color": ["#333", "#ddd"],
   "thumb-color-at-default": ["#ccc", "#777"],
   "track-color": ["#ccc", "#222"],
-  "disabled-color": ["#ddd", "#2e2e2e"],
-  "disabled-text-color": ["#999", "#aaa"],
   "disabled-thumb-color": ["#888", "#bbb"],
   "disabled-thumb-color-at-default": ["#ccc", "#777"],
+  "disabled-track-color": ["#ddd", "#2e2e2e"],
+  "disabled-text-color": ["#999", "#aaa"],
 };
 
 export class RangeSlider extends html.UnlitElement {
@@ -100,7 +100,7 @@ export class RangeSlider extends html.UnlitElement {
 
     .slider:disabled::-webkit-slider-runnable-track {
       height: calc(var(--track-height) * var(--disabled-factor));
-      background: var(--disabled-color);
+      background: var(--disabled-track-color);
     }
 
     /* Firefox */
@@ -135,7 +135,7 @@ export class RangeSlider extends html.UnlitElement {
     .slider:disabled::-moz-range-track {
       border-radius: calc(5px * var(--disabled-factor));
       height: calc(var(--track-height) * var(--disabled-factor));
-      background: var(--disabled-color);
+      background: var(--disabled-track-color);
     }
 
     .range-container > input + div {
@@ -192,8 +192,9 @@ export class RangeSlider extends html.UnlitElement {
       width: 1px;
       background: var(--track-color);
     }
+
     .tickmark.disabled {
-      background: var(--disabled-color);
+      background: var(--disabled-track-color);
     }
   `;
 

--- a/src-js/fontra-webcomponents/src/range-slider.js
+++ b/src-js/fontra-webcomponents/src/range-slider.js
@@ -6,9 +6,9 @@ const colors = {
   "thumb-color": ["#333", "#ddd"],
   "thumb-color-at-default": ["#ccc", "#777"],
   "track-color": ["#ccc", "#222"],
-  "disabled-thumb-color": ["#888", "#bbb"],
-  "disabled-thumb-color-at-default": ["#ccc", "#777"],
-  "disabled-track-color": ["#ddd", "#2e2e2e"],
+  "disabled-thumb-color": ["#b8b8b8", "#aaa"],
+  "disabled-thumb-color-at-default": ["#e5e5e5", "#666"],
+  "disabled-track-color": ["#e5e5e5", "#363636"],
   "disabled-text-color": ["#999", "#aaa"],
 };
 

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -809,7 +809,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     if (forHiddenAxes) {
       menuItems.push({
         title: translate(
-          "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location"
+          "sidebar.designspace-navigation.font-axes-view-options-menu.show-only-effective-location"
         ),
         callback: () => {
           this.sceneSettings[effectiveLocationKey] =

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -381,6 +381,7 @@ export default class DesignspaceNavigationPanel extends Panel {
       [
         "fontAxesUseSourceCoordinates",
         "fontAxesShowEffectiveLocation",
+        "hiddenFontAxesShowEffectiveLocation",
         "fontAxesShowHidden",
         "fontAxesSkipMapping",
       ],
@@ -757,6 +758,9 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   showFontAxesViewOptionsMenu(event, forHiddenAxes) {
+    const effectiveLocationKey = forHiddenAxes
+      ? "hiddenFontAxesShowEffectiveLocation"
+      : "fontAxesShowEffectiveLocation";
     const menuItems = [
       {
         title: translate(
@@ -784,12 +788,25 @@ export default class DesignspaceNavigationPanel extends Panel {
           "sidebar.designspace-navigation.font-axes-view-options-menu.show-effective-location"
         ),
         callback: () => {
-          this.sceneSettings.fontAxesShowEffectiveLocation =
-            !this.sceneSettings.fontAxesShowEffectiveLocation;
+          this.sceneSettings[effectiveLocationKey] =
+            this.sceneSettings[effectiveLocationKey] == 1 ? 0 : 1;
         },
-        checked: this.sceneSettings.fontAxesShowEffectiveLocation,
+        checked: this.sceneSettings[effectiveLocationKey] == 1,
       },
     ];
+
+    if (forHiddenAxes) {
+      menuItems.push({
+        title: translate(
+          "sidebar.designspace-navigation.font-axes-view-options-menu.only-show-effective-location"
+        ),
+        callback: () => {
+          this.sceneSettings[effectiveLocationKey] =
+            this.sceneSettings[effectiveLocationKey] == 2 ? 0 : 2;
+        },
+        checked: this.sceneSettings[effectiveLocationKey] == 2,
+      });
+    }
 
     const button = this.accordion.querySelector(
       forHiddenAxes
@@ -968,11 +985,13 @@ export default class DesignspaceNavigationPanel extends Panel {
       : [...this.hiddenFontAxes];
 
     this.hiddenFontAxesElement.axes = hiddenFontAxes;
-    if (this.sceneSettings.fontAxesShowEffectiveLocation) {
+    if (this.sceneSettings.hiddenFontAxesShowEffectiveLocation) {
       this.hiddenFontAxesElement.phantomAxes = hiddenFontAxesSourceSpace;
     } else {
       this.hiddenFontAxesElement.phantomAxes = [];
     }
+    this.hiddenFontAxesElement.onlyShowPhantomAxes =
+      this.sceneSettings.hiddenFontAxesShowEffectiveLocation == 2;
 
     this.hiddenFontAxesAccordionItem.hidden = !hiddenFontAxesSourceSpace.length;
 

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -785,16 +785,6 @@ export default class DesignspaceNavigationPanel extends Panel {
         },
         checked: this.sceneSettings.fontAxesShowEffectiveLocation,
       },
-      {
-        title: translate(
-          "sidebar.designspace-navigation.font-axes-view-options-menu.show-hidden-axes"
-        ),
-        callback: () => {
-          this.sceneSettings.fontAxesShowHidden =
-            !this.sceneSettings.fontAxesShowHidden;
-        },
-        checked: this.sceneSettings.fontAxesShowHidden,
-      },
     ];
 
     const button = this.accordion.querySelector("#font-axes-view-options-button");

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -71,6 +71,12 @@ const LIST_HEADER_ANIMATION_STYLE = `
 }
 `;
 
+const ShowLocationSettings = {
+  DontShowEffectiveLocation: 0,
+  ShowEffectiveLocation: 1,
+  OnlyShowEffectiveLocation: 2,
+};
+
 export default class DesignspaceNavigationPanel extends Panel {
   identifier = "designspace-navigation";
   iconPath = "/images/sliders.svg";
@@ -789,9 +795,14 @@ export default class DesignspaceNavigationPanel extends Panel {
         ),
         callback: () => {
           this.sceneSettings[effectiveLocationKey] =
-            this.sceneSettings[effectiveLocationKey] == 1 ? 0 : 1;
+            this.sceneSettings[effectiveLocationKey] ==
+            ShowLocationSettings.ShowEffectiveLocation
+              ? ShowLocationSettings.DontShowEffectiveLocation
+              : ShowLocationSettings.ShowEffectiveLocation;
         },
-        checked: this.sceneSettings[effectiveLocationKey] == 1,
+        checked:
+          this.sceneSettings[effectiveLocationKey] ==
+          ShowLocationSettings.ShowEffectiveLocation,
       },
     ];
 
@@ -802,9 +813,14 @@ export default class DesignspaceNavigationPanel extends Panel {
         ),
         callback: () => {
           this.sceneSettings[effectiveLocationKey] =
-            this.sceneSettings[effectiveLocationKey] == 2 ? 0 : 2;
+            this.sceneSettings[effectiveLocationKey] ==
+            ShowLocationSettings.OnlyShowEffectiveLocation
+              ? ShowLocationSettings.DontShowEffectiveLocation
+              : ShowLocationSettings.OnlyShowEffectiveLocation;
         },
-        checked: this.sceneSettings[effectiveLocationKey] == 2,
+        checked:
+          this.sceneSettings[effectiveLocationKey] ==
+          ShowLocationSettings.OnlyShowEffectiveLocation,
       });
     }
 

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -182,6 +182,45 @@ export default class DesignspaceNavigationPanel extends Panel {
         ]),
       },
       {
+        id: "hidden-font-axes-accordion-item",
+        label: "Hidden font axes", // translate("sidebar.designspace-navigation.font-axes"),
+        open: false, // TODO make persistent?
+        content: html.createDomElement(
+          "designspace-location",
+          { id: "hidden-font-axes", style: "height: 100%;" },
+          []
+        ),
+        auxiliaryHeaderElement: groupAccordionHeaderButtons([
+          //   makeAccordionHeaderButton({
+          //     icon: "menu-2",
+          //     id: "font-axes-view-options-button",
+          //     tooltip: translate(
+          //       "sidebar.designspace-navigation.font-axes-view-options-button.tooltip"
+          //     ),
+          //     onclick: (event) => this.showFontAxesViewOptionsMenu(event),
+          //   }),
+          makeAccordionHeaderButton({
+            icon: "tool",
+            tooltip: translate("sidebar.designspace-navigation.font-axes.edit"),
+            onclick: (event) => {
+              const url = new URL(window.location);
+              url.pathname = url.pathname.replace("/editor.html", "/fontinfo.html");
+              url.hash = "#axes-panel";
+              window.open(
+                url.toString(),
+                `fontra.fontinfo.${this.editorController.projectIdentifier}`
+              );
+            },
+          }),
+          makeAccordionHeaderButton({
+            icon: "refresh",
+            id: "reset-hidden-font-axes-button",
+            tooltip: translate("sidebar.designspace-navigation.font-axes.reset"),
+            onclick: (event) => this.resetHiddenFontAxesToDefault(),
+          }),
+        ]),
+      },
+      {
         id: "glyph-axes-accordion-item",
         label: translate("sidebar.designspace-navigation.glyph-axes"),
         open: true,
@@ -262,6 +301,10 @@ export default class DesignspaceNavigationPanel extends Panel {
     return this.accordion.querySelector("#font-axes");
   }
 
+  get hiddenFontAxesElement() {
+    return this.accordion.querySelector("#hidden-font-axes");
+  }
+
   get glyphAxesElement() {
     return this.accordion.querySelector("#glyph-axes");
   }
@@ -282,26 +325,33 @@ export default class DesignspaceNavigationPanel extends Panel {
     this._setFontLocationValues();
     this.glyphAxesElement.values = this.sceneSettings.glyphLocation;
 
+    const setFontLocation = (event) => {
+      this.sceneController.scrollAdjustBehavior =
+        this.getScrollAdjustBehavior("pin-glyph-center");
+      this.sceneController.autoViewBox = false;
+
+      this.sceneSettingsController.setItem(
+        this.sceneSettings.fontAxesUseSourceCoordinates
+          ? "fontLocationSource"
+          : "fontLocationUser",
+        { ...this.fontAxesElement.values, ...this.hiddenFontAxesElement.values },
+        { senderID: this }
+      );
+    };
+
     this.fontAxesElement.addEventListener(
       "locationChanged",
-      scheduleCalls(async (event) => {
-        this.sceneController.scrollAdjustBehavior =
-          this.getScrollAdjustBehavior("pin-glyph-center");
-        this.sceneController.autoViewBox = false;
+      scheduleCalls(setFontLocation)
+    );
 
-        this.sceneSettingsController.setItem(
-          this.sceneSettings.fontAxesUseSourceCoordinates
-            ? "fontLocationSource"
-            : "fontLocationUser",
-          { ...this.fontAxesElement.values },
-          { senderID: this }
-        );
-      })
+    this.hiddenFontAxesElement.addEventListener(
+      "locationChanged",
+      scheduleCalls(setFontLocation)
     );
 
     this.glyphAxesElement.addEventListener(
       "locationChanged",
-      scheduleCalls(async (event) => {
+      scheduleCalls((event) => {
         this.sceneController.scrollAdjustBehavior =
           this.getScrollAdjustBehavior("pin-glyph-center");
         this.sceneController.autoViewBox = false;
@@ -673,8 +723,18 @@ export default class DesignspaceNavigationPanel extends Panel {
     const locationKey = this.sceneSettings.fontAxesUseSourceCoordinates
       ? "fontLocationSource"
       : "fontLocationUser";
-    this.fontAxesElement.values = this.sceneSettings[locationKey];
+    this.fontAxesElement.values = filterLocation(
+      this.sceneSettings[locationKey],
+      this.fontAxes
+    );
     this.fontAxesElement.phantomValues = this.sceneSettings.fontLocationSourceMapped;
+
+    this.hiddenFontAxesElement.values = filterLocation(
+      this.sceneSettings[locationKey],
+      this.hiddenFontAxes
+    );
+    this.hiddenFontAxesElement.phantomValues =
+      this.sceneSettings.fontLocationSourceMapped;
   }
 
   sourceListGetSourceItem(sourceIndex) {
@@ -772,7 +832,17 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   resetFontAxesToDefault(event) {
-    this.sceneSettings.fontLocationUser = {};
+    this.sceneSettings.fontLocationUser = filterLocation(
+      this.sceneSettings.fontLocationUser,
+      this.hiddenFontAxes
+    );
+  }
+
+  resetHiddenFontAxesToDefault(event) {
+    this.sceneSettings.fontLocationUser = filterLocation(
+      this.sceneSettings.fontLocationUser,
+      this.fontAxes
+    );
   }
 
   resetGlyphAxesToDefault(event) {
@@ -781,12 +851,23 @@ export default class DesignspaceNavigationPanel extends Panel {
 
   _updateResetAllAxesButtonState() {
     let button;
+
     const fontAxesSourceSpace = mapAxesFromUserSpaceToSourceSpace(this.fontAxes);
     button = this.accordion.querySelector("#reset-font-axes-button");
     button.disabled = isLocationAtDefault(
       this.sceneSettings.fontLocationSourceMapped,
       fontAxesSourceSpace
     );
+
+    const hiddenFontAxesSourceSpace = mapAxesFromUserSpaceToSourceSpace(
+      this.hiddenFontAxes
+    );
+    button = this.accordion.querySelector("#reset-hidden-font-axes-button");
+    button.disabled = isLocationAtDefault(
+      this.sceneSettings.fontLocationSourceMapped,
+      hiddenFontAxesSourceSpace
+    );
+
     button = this.accordion.querySelector("#reset-glyph-axes-button");
     button.disabled = isLocationAtDefault(
       this.sceneSettings.glyphLocation,
@@ -856,9 +937,11 @@ export default class DesignspaceNavigationPanel extends Panel {
   }
 
   get fontAxes() {
-    return this.sceneSettings.fontAxesShowHidden
-      ? this.fontController.fontAxes
-      : this.fontController.fontAxes.filter((axis) => !axis.hidden);
+    return this.fontController.fontAxes.filter((axis) => !axis.hidden);
+  }
+
+  get hiddenFontAxes() {
+    return this.fontController.fontAxes.filter((axis) => axis.hidden);
   }
 
   async _updateAxes() {
@@ -871,12 +954,28 @@ export default class DesignspaceNavigationPanel extends Panel {
     const fontAxes = this.sceneSettings.fontAxesUseSourceCoordinates
       ? fontAxesSourceSpace
       : [...this.fontAxes];
+
     this.fontAxesElement.axes = fontAxes;
     if (this.sceneSettings.fontAxesShowEffectiveLocation) {
       this.fontAxesElement.phantomAxes = fontAxesSourceSpace;
     } else {
       this.fontAxesElement.phantomAxes = [];
     }
+
+    const hiddenFontAxesSourceSpace = mapAxesFromUserSpaceToSourceSpace(
+      this.hiddenFontAxes
+    );
+    const hiddenFontAxes = this.sceneSettings.fontAxesUseSourceCoordinates
+      ? hiddenFontAxesSourceSpace
+      : [...this.hiddenFontAxes];
+
+    this.hiddenFontAxesElement.axes = hiddenFontAxes;
+    if (this.sceneSettings.fontAxesShowEffectiveLocation) {
+      this.hiddenFontAxesElement.phantomAxes = hiddenFontAxesSourceSpace;
+    } else {
+      this.hiddenFontAxesElement.phantomAxes = [];
+    }
+
     this._setFontLocationValues();
   }
 
@@ -2315,4 +2414,16 @@ function getSourceCompareFunc(locationProperty, axisNames) {
   };
 }
 
+function filterLocation(location, axes) {
+  const filteredLocation = {};
+
+  for (const axis of axes) {
+    const value = location[axis.name];
+    if (value !== undefined) {
+      filteredLocation[axis.name] = value;
+    }
+  }
+
+  return filteredLocation;
+}
 customElements.define("panel-designspace-navigation", DesignspaceNavigationPanel);

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -158,7 +158,7 @@ export default class DesignspaceNavigationPanel extends Panel {
             tooltip: translate(
               "sidebar.designspace-navigation.font-axes-view-options-button.tooltip"
             ),
-            onclick: (event) => this.showFontAxesViewOptionsMenu(event),
+            onclick: (event) => this.showFontAxesViewOptionsMenu(event, false),
           }),
           makeAccordionHeaderButton({
             icon: "tool",
@@ -191,14 +191,14 @@ export default class DesignspaceNavigationPanel extends Panel {
           []
         ),
         auxiliaryHeaderElement: groupAccordionHeaderButtons([
-          //   makeAccordionHeaderButton({
-          //     icon: "menu-2",
-          //     id: "font-axes-view-options-button",
-          //     tooltip: translate(
-          //       "sidebar.designspace-navigation.font-axes-view-options-button.tooltip"
-          //     ),
-          //     onclick: (event) => this.showFontAxesViewOptionsMenu(event),
-          //   }),
+          makeAccordionHeaderButton({
+            icon: "menu-2",
+            id: "hidden-font-axes-view-options-button",
+            tooltip: translate(
+              "sidebar.designspace-navigation.font-axes-view-options-button.tooltip"
+            ),
+            onclick: (event) => this.showFontAxesViewOptionsMenu(event, true),
+          }),
           makeAccordionHeaderButton({
             icon: "tool",
             tooltip: translate("sidebar.designspace-navigation.font-axes.edit"),
@@ -752,7 +752,7 @@ export default class DesignspaceNavigationPanel extends Panel {
     }
   }
 
-  showFontAxesViewOptionsMenu(event) {
+  showFontAxesViewOptionsMenu(event, forHiddenAxes) {
     const menuItems = [
       {
         title: translate(
@@ -787,7 +787,11 @@ export default class DesignspaceNavigationPanel extends Panel {
       },
     ];
 
-    const button = this.accordion.querySelector("#font-axes-view-options-button");
+    const button = this.accordion.querySelector(
+      forHiddenAxes
+        ? "#hidden-font-axes-view-options-button"
+        : "#font-axes-view-options-button"
+    );
     const buttonRect = button.getBoundingClientRect();
     showMenu(menuItems, { x: buttonRect.left, y: buttonRect.bottom });
   }

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -309,6 +309,10 @@ export default class DesignspaceNavigationPanel extends Panel {
     return this.accordion.querySelector("#glyph-axes");
   }
 
+  get hiddenFontAxesAccordionItem() {
+    return this.accordion.querySelector("#hidden-font-axes-accordion-item");
+  }
+
   get glyphAxesAccordionItem() {
     return this.accordion.querySelector("#glyph-axes-accordion-item");
   }
@@ -969,6 +973,8 @@ export default class DesignspaceNavigationPanel extends Panel {
     } else {
       this.hiddenFontAxesElement.phantomAxes = [];
     }
+
+    this.hiddenFontAxesAccordionItem.hidden = !hiddenFontAxesSourceSpace.length;
 
     this._setFontLocationValues();
   }

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -1821,6 +1821,7 @@ const persistentSceneSettings = [
   // "glyphLocations", // handled separately
   { key: "fontAxesUseSourceCoordinates" },
   { key: "fontAxesShowEffectiveLocation" },
+  { key: "hiddenFontAxesShowEffectiveLocation" },
   { key: "fontAxesShowHidden" },
   { key: "fontAxesSkipMapping" },
   { key: "fontLocationUser", infoKey: "location" },
@@ -1848,6 +1849,7 @@ function getSceneSettingsDefaults() {
     fontLocationSourceMapped: {},
     fontAxesUseSourceCoordinates: false,
     fontAxesShowEffectiveLocation: false,
+    hiddenFontAxesShowEffectiveLocation: false,
     fontAxesShowHidden: false,
     fontAxesSkipMapping: false,
     glyphLocation: {},


### PR DESCRIPTION
This improves some of #2553, especially when a font contains many regular axes and many hidden axes such as [Amstelvar](https://github.com/googlefonts/amstelvar-avar2).

- Move hidden axes to a separate accordion section, so they can be scrolled independently from the non-hidden axes. (If there are many.)
- For hidden axes, add "Show only effective location" menu option, for more compact vertical layout if we don't need to move the sliders manually.
- The special "disabled" sliders now also show by the color of the thumb whether its value is at the default or not