### PR TITLE
Begin typescript conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "codemirror": "^6.0.2"
       },
       "devDependencies": {
+        "@types/emscripten": "^1.41.5",
         "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^7.1.4",
         "html-bundler-webpack-plugin": "^4.23.0",
@@ -1967,6 +1968,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "type": "module",
   "devDependencies": {
+    "@types/emscripten": "^1.41.5",
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^7.1.4",
     "html-bundler-webpack-plugin": "^4.23.0",

--- a/src-js/fontra-core/src/actions.js
+++ b/src-js/fontra-core/src/actions.js
@@ -6,7 +6,7 @@ import {
   commandKeyProperty,
   isActiveElementTypeable,
   isMac,
-} from "./utils.js";
+} from "./utils.ts";
 
 // Action Info
 // const {

--- a/src-js/fontra-core/src/backend-api.js
+++ b/src-js/fontra-core/src/backend-api.js
@@ -1,5 +1,5 @@
 import { getRemoteProxy } from "@fontra/core/remote.js";
-import { fetchJSON } from "./utils.js";
+import { fetchJSON } from "./utils.ts";
 import { StaticGlyph } from "./var-glyph.js";
 import { VarPackedPath } from "./var-path.js";
 /** @import { RemoteFont } from "remotefont" */

--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,4 +1,4 @@
-import { normalizeRect, rectCenter, validateRect } from "./rectangle.js";
+import { normalizeRect, rectCenter, validateRect } from "./rectangle.ts";
 import { assert, clamp, consolidateCalls, isNumber, withSavedState } from "./utils.js";
 
 const DEFAULT_MIN_MAGNIFICATION = 0.005;

--- a/src-js/fontra-core/src/canvas-controller.js
+++ b/src-js/fontra-core/src/canvas-controller.js
@@ -1,5 +1,5 @@
 import { normalizeRect, rectCenter, validateRect } from "./rectangle.ts";
-import { assert, clamp, consolidateCalls, isNumber, withSavedState } from "./utils.js";
+import { assert, clamp, consolidateCalls, isNumber, withSavedState } from "./utils.ts";
 
 const DEFAULT_MIN_MAGNIFICATION = 0.005;
 const DEFAULT_MAX_MAGNIFICATION = 200;

--- a/src-js/fontra-core/src/change-recorder.js
+++ b/src-js/fontra-core/src/change-recorder.js
@@ -1,5 +1,5 @@
 import { ChangeCollector, applyChange } from "./changes.js";
-import { range } from "./utils.js";
+import { range } from "./utils.ts";
 import VarArray from "./var-array.js";
 import { VarPackedPath } from "./var-path.js";
 

--- a/src-js/fontra-core/src/changes.js
+++ b/src-js/fontra-core/src/changes.js
@@ -1,4 +1,4 @@
-import { deepCopyObject } from "./utils.js";
+import { deepCopyObject } from "./utils.ts";
 
 export class ChangeCollector {
   constructor(parentCollector, path) {

--- a/src-js/fontra-core/src/character-lines.js
+++ b/src-js/fontra-core/src/character-lines.js
@@ -1,5 +1,5 @@
 import { getCodePointFromGlyphName, getSuggestedGlyphName } from "./glyph-data.js";
-import { assert, splitGlyphNameExtension } from "./utils.js";
+import { assert, splitGlyphNameExtension } from "./utils.ts";
 
 export function characterLinesFromString(
   string,

--- a/src-js/fontra-core/src/classes.js
+++ b/src-js/fontra-core/src/classes.js
@@ -1,5 +1,5 @@
 import coreClasses from "./classes.json" with { type: "json" };
-import { mapObjectValues } from "./utils.js";
+import { mapObjectValues } from "./utils.ts";
 import { Layer, StaticGlyph, VariableGlyph } from "./var-glyph.js";
 import { VarPackedPath } from "./var-path.js";
 

--- a/src-js/fontra-core/src/cmap.js
+++ b/src-js/fontra-core/src/cmap.js
@@ -1,4 +1,4 @@
-import { makeUPlusStringFromCodePoint } from "./utils.js";
+import { makeUPlusStringFromCodePoint } from "./utils.ts";
 
 //
 // A `characterMap` is an object with integer numbers representing unicode code

--- a/src-js/fontra-core/src/convex-hull.js
+++ b/src-js/fontra-core/src/convex-hull.js
@@ -1,4 +1,4 @@
-import { equalRect, normalizeRect, sectRect } from "./rectangle.js";
+import { equalRect, normalizeRect, sectRect } from "./rectangle.ts";
 import { compare, reversed } from "./utils.js";
 
 export function pointInConvexPolygon(x, y, polygon) {

--- a/src-js/fontra-core/src/convex-hull.js
+++ b/src-js/fontra-core/src/convex-hull.js
@@ -1,5 +1,5 @@
 import { equalRect, normalizeRect, sectRect } from "./rectangle.ts";
-import { compare, reversed } from "./utils.js";
+import { compare, reversed } from "./utils.ts";
 
 export function pointInConvexPolygon(x, y, polygon) {
   // Adapted from a comment on

--- a/src-js/fontra-core/src/cross-axis-mapping.js
+++ b/src-js/fontra-core/src/cross-axis-mapping.js
@@ -1,6 +1,6 @@
 // avar-2-style Cross-Axis Mapping
 
-import { zip } from "./utils.js";
+import { zip } from "./utils.ts";
 import {
   VariationModel,
   makeSparseNormalizedLocation,

--- a/src-js/fontra-core/src/discrete-variation-model.js
+++ b/src-js/fontra-core/src/discrete-variation-model.js
@@ -1,5 +1,5 @@
 import { VariationError } from "./errors.js";
-import { assert, enumerate, isObjectEmpty, product, range, zip } from "./utils.js";
+import { assert, enumerate, isObjectEmpty, product, range, zip } from "./utils.ts";
 import {
   VariationModel,
   makeSparseNormalizedLocation,

--- a/src-js/fontra-core/src/fit-cubic.js
+++ b/src-js/fontra-core/src/fit-cubic.js
@@ -1,5 +1,5 @@
 import { Bezier } from "bezier-js";
-import { enumerate, range } from "./utils.js";
+import { enumerate, range } from "./utils.ts";
 import {
   addVectors,
   dotVector,

--- a/src-js/fontra-core/src/font-controller.js
+++ b/src-js/fontra-core/src/font-controller.js
@@ -30,7 +30,7 @@ import {
   sleepAsync,
   throttleCalls,
   uniqueID,
-} from "./utils.js";
+} from "./utils.ts";
 import { StaticGlyph, VariableGlyph } from "./var-glyph.js";
 import {
   locationToName,

--- a/src-js/fontra-core/src/font-sources-instancer.js
+++ b/src-js/fontra-core/src/font-sources-instancer.js
@@ -4,7 +4,7 @@ import {
   areCustomDatasCompatible,
   areGuidelinesCompatible,
   normalizeGuidelines,
-} from "./utils.js";
+} from "./utils.ts";
 import { locationToString } from "./var-model.js";
 
 export class FontSourcesInstancer {

--- a/src-js/fontra-core/src/fontra-backend.js
+++ b/src-js/fontra-core/src/fontra-backend.js
@@ -1,4 +1,4 @@
-import { assert, enumerate } from "./utils.js";
+import { assert, enumerate } from "./utils.ts";
 
 function getFontDefaults() {
   return { unitsPerEm: 1000, axes: { axes: [] } };

--- a/src-js/fontra-core/src/fontra-menus.js
+++ b/src-js/fontra-core/src/fontra-menus.js
@@ -8,7 +8,7 @@ import {
   dumpURLFragment,
   isObjectEmpty,
   readObjectFromURLFragment,
-} from "./utils.js";
+} from "./utils.ts";
 
 const mapMenuItemKeyToFunction = {
   File: getFileMenuItems,

--- a/src-js/fontra-core/src/formatters.js
+++ b/src-js/fontra-core/src/formatters.js
@@ -1,4 +1,4 @@
-import { assert } from "./utils.js";
+import { assert } from "./utils.ts";
 export function isString(value) {
   return typeof value === "string" || value instanceof String;
 }

--- a/src-js/fontra-core/src/glyph-controller.js
+++ b/src-js/fontra-core/src/glyph-controller.js
@@ -16,7 +16,7 @@ import {
   rectToPoints,
   sectRect,
   unionRect,
-} from "./rectangle.js";
+} from "./rectangle.ts";
 import {
   getRepresentation,
   registerRepresentationFactory,

--- a/src-js/fontra-core/src/glyph-controller.js
+++ b/src-js/fontra-core/src/glyph-controller.js
@@ -39,7 +39,7 @@ import {
   range,
   reversed,
   zip,
-} from "./utils.js";
+} from "./utils.ts";
 import { addItemwise } from "./var-funcs.js";
 import { StaticGlyph, copyComponent } from "./var-glyph.js";
 import {

--- a/src-js/fontra-core/src/glyph-data.js
+++ b/src-js/fontra-core/src/glyph-data.js
@@ -3,7 +3,7 @@ import {
   enumerate,
   getCharFromCodePoint,
   splitGlyphNameExtension,
-} from "./utils.js";
+} from "./utils.ts";
 
 let glyphDataCSV;
 

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -5,7 +5,7 @@ import {
   getBaseGlyphName,
   getCodePointFromGlyphItem,
   getGlyphNameExtension,
-} from "./utils.js";
+} from "./utils.ts";
 
 function getGlyphInfo(codePoint, glyphName) {
   return (

--- a/src-js/fontra-core/src/glyphsets-controller.js
+++ b/src-js/fontra-core/src/glyphsets-controller.js
@@ -1,7 +1,7 @@
 import { getGlyphMapProxy } from "./cmap.js";
 import { ObservableController } from "./observable-object.js";
 import { parseGlyphSet, redirectGlyphSetURL } from "./parse-glyphset.js";
-import { assert, friendlyHttpStatus, sleepAsync } from "./utils.js";
+import { assert, friendlyHttpStatus, sleepAsync } from "./utils.ts";
 
 export const THIS_FONTS_GLYPHSET = "";
 export const PROJECT_GLYPH_SETS_CUSTOM_DATA_KEY = "fontra.projectGlyphSets";

--- a/src-js/fontra-core/src/glyphsets-ui.js
+++ b/src-js/fontra-core/src/glyphsets-ui.js
@@ -12,7 +12,7 @@ import {
   labeledTextInput,
   popupSelect,
 } from "./ui-utils.js";
-import { fetchJSON } from "./utils.js";
+import { fetchJSON } from "./utils.ts";
 
 export const glyphSetsUIStyles = `
 .glyph-set-container {

--- a/src-js/fontra-core/src/html-utils.js
+++ b/src-js/fontra-core/src/html-utils.js
@@ -1,7 +1,7 @@
 // This is a tiny subset of a few things that Lit does, except it uses
 // object notation to construct dom elements instead of HTML.
 
-import { consolidateCalls } from "./utils.js";
+import { consolidateCalls } from "./utils.ts";
 
 export class SimpleElement extends HTMLElement {
   constructor() {

--- a/src-js/fontra-core/src/kerning-controller.js
+++ b/src-js/fontra-core/src/kerning-controller.js
@@ -1,7 +1,7 @@
 import { recordChanges } from "./change-recorder.js";
 import { ChangeCollector, iterChanges, wildcard } from "./changes.js";
 import { DiscreteVariationModel } from "./discrete-variation-model.js";
-import { assert, enumerate, isObjectEmpty, throttleCalls, zip } from "./utils.js";
+import { assert, enumerate, isObjectEmpty, throttleCalls, zip } from "./utils.ts";
 
 export class KerningController {
   constructor(kernTag, kerning, fontController) {

--- a/src-js/fontra-core/src/observable-object.js
+++ b/src-js/fontra-core/src/observable-object.js
@@ -1,4 +1,4 @@
-import { assert, chain } from "./utils.js";
+import { assert, chain } from "./utils.ts";
 
 export const controllerKey = Symbol("controller-key");
 

--- a/src-js/fontra-core/src/opfs.js
+++ b/src-js/fontra-core/src/opfs.js
@@ -1,4 +1,4 @@
-import { assert, withTimeout } from "./utils.js";
+import { assert, withTimeout } from "./utils.ts";
 
 export async function getOPFS() {
   return new FileSystem(

--- a/src-js/fontra-core/src/path-functions.js
+++ b/src-js/fontra-core/src/path-functions.js
@@ -11,7 +11,7 @@ import {
   reversed,
   uniqueID,
   zip,
-} from "./utils.js";
+} from "./utils.ts";
 import {
   POINT_TYPE_OFF_CURVE_CUBIC,
   POINT_TYPE_OFF_CURVE_QUAD,

--- a/src-js/fontra-core/src/path-hit-tester.js
+++ b/src-js/fontra-core/src/path-hit-tester.js
@@ -5,7 +5,7 @@ import {
   rectSize,
   sectRect,
   unionRect,
-} from "./rectangle.js";
+} from "./rectangle.ts";
 import { enumerate, pointCompareFunc, range, reversedEnumerate } from "./utils.js";
 import * as vector from "./vector.js";
 

--- a/src-js/fontra-core/src/path-hit-tester.js
+++ b/src-js/fontra-core/src/path-hit-tester.js
@@ -6,7 +6,7 @@ import {
   sectRect,
   unionRect,
 } from "./rectangle.ts";
-import { enumerate, pointCompareFunc, range, reversedEnumerate } from "./utils.js";
+import { enumerate, pointCompareFunc, range, reversedEnumerate } from "./utils.ts";
 import * as vector from "./vector.js";
 
 export class PathHitTester {

--- a/src-js/fontra-core/src/rectangle.ts
+++ b/src-js/fontra-core/src/rectangle.ts
@@ -1,16 +1,35 @@
 import { isNumber } from "./utils.js";
 
-export function pointInRect(x, y, rect) {
+export type Point = {
+  x: number;
+  y: number;
+};
+
+export type Rect = {
+  xMin: number;
+  yMin: number;
+  xMax: number;
+  yMax: number;
+};
+
+export type Size = {
+  width: number;
+  height: number;
+};
+
+export function pointInRect(x: number, y: number, rect: Rect) {
   if (!rect) {
     return false;
   }
   return x >= rect.xMin && x <= rect.xMax && y >= rect.yMin && y <= rect.yMax;
 }
 
-export function centeredRect(x, y, width, height) {
-  if (height === undefined) {
-    height = width;
-  }
+export function centeredRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number = width
+) {
   const halfWidth = width / 2;
   const halfHeight = height / 2;
   return {
@@ -21,17 +40,16 @@ export function centeredRect(x, y, width, height) {
   };
 }
 
-export function normalizeRect(rect) {
-  const nRect = {
+export function normalizeRect(rect: Rect): Rect {
+  return {
     xMin: Math.min(rect.xMin, rect.xMax),
     yMin: Math.min(rect.yMin, rect.yMax),
     xMax: Math.max(rect.xMin, rect.xMax),
     yMax: Math.max(rect.yMin, rect.yMax),
   };
-  return nRect;
 }
 
-export function sectRect(rect1, rect2) {
+export function sectRect(rect1: Rect, rect2: Rect): Rect | undefined {
   // Test for rectangle-rectangle intersection.
 
   // Args:
@@ -52,7 +70,7 @@ export function sectRect(rect1, rect2) {
   return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
 }
 
-export function unionRect(...rectangles) {
+export function unionRect(...rectangles: Rect[]): Rect | undefined {
   if (!rectangles.length) {
     return undefined;
   }
@@ -71,7 +89,7 @@ export function unionRect(...rectangles) {
   return { xMin: xMin, yMin: yMin, xMax: xMax, yMax: yMax };
 }
 
-export function offsetRect(rect, x, y) {
+export function offsetRect(rect: Rect, x: number, y: number): Rect {
   return {
     xMin: rect.xMin + x,
     yMin: rect.yMin + y,
@@ -80,10 +98,7 @@ export function offsetRect(rect, x, y) {
   };
 }
 
-export function scaleRect(rect, sx, sy) {
-  if (sy === undefined) {
-    sy = sx;
-  }
+export function scaleRect(rect: Rect, sx: number, sy: number = sx): Rect {
   return {
     xMin: rect.xMin * sx,
     yMin: rect.yMin * sy,
@@ -92,7 +107,7 @@ export function scaleRect(rect, sx, sy) {
   };
 }
 
-export function insetRect(rect, dx, dy) {
+export function insetRect(rect: Rect, dx: number, dy: number): Rect {
   return {
     xMin: rect.xMin + dx,
     yMin: rect.yMin + dy,
@@ -101,7 +116,7 @@ export function insetRect(rect, dx, dy) {
   };
 }
 
-export function equalRect(rect1, rect2) {
+export function equalRect(rect1: Rect, rect2: Rect) {
   return (
     rect1.xMin === rect2.xMin &&
     rect1.yMin === rect2.yMin &&
@@ -110,34 +125,42 @@ export function equalRect(rect1, rect2) {
   );
 }
 
-export function rectCenter(rect) {
-  return { x: (rect.xMin + rect.xMax) / 2, y: (rect.yMin + rect.yMax) / 2 };
+export function rectCenter(rect: Rect): Point {
+  return {
+    x: (rect.xMin + rect.xMax) / 2,
+    y: (rect.yMin + rect.yMax) / 2,
+  };
 }
 
-export function rectSize(rect) {
+export function rectSize(rect: Rect): Size {
   return {
     width: Math.abs(rect.xMax - rect.xMin),
     height: Math.abs(rect.yMax - rect.yMin),
   };
 }
 
-export function rectFromArray(array) {
+export function rectFromArray(array: [number, number, number, number]): Rect {
   if (array.length != 4) {
     throw new Error("rect array must have length == 4");
   }
-  return { xMin: array[0], yMin: array[1], xMax: array[2], yMax: array[3] };
+  return {
+    xMin: array[0],
+    yMin: array[1],
+    xMax: array[2],
+    yMax: array[3],
+  };
 }
 
-export function rectToArray(rect) {
+export function rectToArray(rect: Rect): [number, number, number, number] {
   return [rect.xMin, rect.yMin, rect.xMax, rect.yMax];
 }
 
-export function isEmptyRect(rect) {
+export function isEmptyRect(rect: Rect) {
   const size = rectSize(rect);
   return size.width === 0 && size.height === 0;
 }
 
-export function rectFromPoints(points) {
+export function rectFromPoints(points: Point[]): Rect | undefined {
   if (!points.length) {
     return undefined;
   }
@@ -155,7 +178,7 @@ export function rectFromPoints(points) {
   return { xMin, yMin, xMax, yMax };
 }
 
-export function rectToPoints(rect) {
+export function rectToPoints(rect: Rect): [Point, Point, Point, Point] {
   return [
     { x: rect.xMin, y: rect.yMin },
     { x: rect.xMax, y: rect.yMin },
@@ -164,7 +187,7 @@ export function rectToPoints(rect) {
   ];
 }
 
-export function updateRect(rect, point) {
+export function updateRect(rect: Rect, point: Point): Rect {
   // Return the smallest rect that includes the original rect and the given point
   return {
     xMin: Math.min(rect.xMin, point.x),
@@ -174,7 +197,7 @@ export function updateRect(rect, point) {
   };
 }
 
-export function rectAddMargin(rect, relativeMargin) {
+export function rectAddMargin(rect: Rect, relativeMargin: number) {
   const size = rectSize(rect);
   const inset =
     size.width > size.height
@@ -183,14 +206,14 @@ export function rectAddMargin(rect, relativeMargin) {
   return insetRect(rect, -inset, -inset);
 }
 
-export function rectScaleAroundCenter(rect, scaleFactor, center) {
+export function rectScaleAroundCenter(rect: Rect, scaleFactor: number, center: Point) {
   rect = offsetRect(rect, -center.x, -center.y);
   rect = scaleRect(rect, scaleFactor);
   rect = offsetRect(rect, center.x, center.y);
   return rect;
 }
 
-export function rectRound(rect) {
+export function rectRound(rect: Rect): Rect {
   return {
     xMin: Math.round(rect.xMin),
     yMin: Math.round(rect.yMin),
@@ -199,7 +222,7 @@ export function rectRound(rect) {
   };
 }
 
-export function validateRect(rect) {
+export function validateRect(rect: Rect) {
   if (
     !rect ||
     !isNumber(rect.xMin) ||

--- a/src-js/fontra-core/src/rectangle.ts
+++ b/src-js/fontra-core/src/rectangle.ts
@@ -49,17 +49,19 @@ export function normalizeRect(rect: Rect): Rect {
   };
 }
 
+/**
+ * Test for rectangle-rectangle intersection.
+ *
+ * @param rect1 First bounding rectangle
+ * @param rect2 Second bounding rectangle
+ *
+ * @returns
+ * A rectangle or undefined.
+ *
+ * If the input rectangles intersect, returns the intersecting rectangle.
+ * Returns ``undefined`` if the input rectangles do not intersect.
+ */
 export function sectRect(rect1: Rect, rect2: Rect): Rect | undefined {
-  // Test for rectangle-rectangle intersection.
-
-  // Args:
-  //     rect1: First bounding rectangle
-  //     rect2: Second bounding rectangle
-
-  // Returns:
-  //     A rectangle or undefined.
-  //     If the input rectangles intersect, returns the intersecting rectangle.
-  //     Returns ``undefined`` if the input rectangles do not intersect.
   const xMin = Math.max(rect1.xMin, rect2.xMin);
   const yMin = Math.max(rect1.yMin, rect2.yMin);
   const xMax = Math.min(rect1.xMax, rect2.xMax);
@@ -187,8 +189,10 @@ export function rectToPoints(rect: Rect): [Point, Point, Point, Point] {
   ];
 }
 
+/**
+ * Return the smallest rect that includes the original rect and the given point.
+ */
 export function updateRect(rect: Rect, point: Point): Rect {
-  // Return the smallest rect that includes the original rect and the given point
   return {
     xMin: Math.min(rect.xMin, point.x),
     yMin: Math.min(rect.yMin, point.y),

--- a/src-js/fontra-core/src/rectangle.ts
+++ b/src-js/fontra-core/src/rectangle.ts
@@ -1,4 +1,4 @@
-import { isNumber } from "./utils.js";
+import { isNumber } from "./utils.ts";
 
 export type Point = {
   x: number;

--- a/src-js/fontra-core/src/scene-view.js
+++ b/src-js/fontra-core/src/scene-view.js
@@ -1,4 +1,4 @@
-import { withSavedState } from "./utils.js";
+import { withSavedState } from "./utils.ts";
 
 export class SceneView {
   constructor(model, drawFunc) {

--- a/src-js/fontra-core/src/shaper-controller.js
+++ b/src-js/fontra-core/src/shaper-controller.js
@@ -3,7 +3,7 @@ import { collectGlyphNames } from "./changes.js";
 import { getGlyphInfoFromCodePoint, getGlyphInfoFromGlyphName } from "./glyph-data.js";
 import { ObservableController } from "./observable-object.js";
 import { getShaper } from "./shaper.js";
-import { consolidateCalls, filterObject, scheduleCalls } from "./utils.js";
+import { consolidateCalls, filterObject, scheduleCalls } from "./utils.ts";
 import { piecewiseLinearMap } from "./var-model.js";
 
 export class ShaperController {

--- a/src-js/fontra-core/src/shaper.js
+++ b/src-js/fontra-core/src/shaper.js
@@ -1,5 +1,5 @@
 import * as hb from "harfbuzzjs";
-import { assert, enumerate, mapObjectValues, range, reversed } from "./utils.js";
+import { assert, enumerate, mapObjectValues, range, reversed } from "./utils.ts";
 
 export function getShaper(shaperSupport) {
   const shaperClass = shaperSupport.fontData ? HBShaper : DumbShaper;

--- a/src-js/fontra-core/src/ui-utils.js
+++ b/src-js/fontra-core/src/ui-utils.js
@@ -1,7 +1,7 @@
 import { PopupMenu } from "@fontra/web-components/popup-menu.js";
 import { DefaultFormatter } from "./formatters.js";
 import * as html from "./html-utils.js";
-import { uniqueID, zip } from "./utils.js";
+import { uniqueID, zip } from "./utils.ts";
 
 const containerClassName = "fontra-ui-sortable-list-container";
 const draggingClassName = "fontra-ui-sortable-list-dragging";

--- a/src-js/fontra-core/src/unicode-scripts-blocks.js
+++ b/src-js/fontra-core/src/unicode-scripts-blocks.js
@@ -1,4 +1,4 @@
-import { bisect_right } from "./utils.js";
+import { bisect_right } from "./utils.ts";
 
 // This module is derived from fontTools.unicodedata.*
 

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -3,8 +3,10 @@ import type { Point } from "./rectangle.ts";
 import { Transform } from "./transform.js";
 import { addItemwise } from "./var-funcs.js";
 
+/**
+ * Shallow object compare. Arguments may be null or undefined
+ */
 export function objectsEqual(obj1: any, obj2: any) {
-  // Shallow object compare. Arguments may be null or undefined
   if (!obj1 || !obj2) {
     return obj1 === obj2;
   }
@@ -29,15 +31,19 @@ export function withSavedState(context: CanvasRenderingContext2D, func: () => vo
   }
 }
 
+/**
+ * Return a function that will request `func` to be called in the next
+ * iteration of the event loop. If it gets called again before `func` was
+ * actually called, ignore the call.
+ *
+ * This ensures that multiple calls within the same event loop cycle get
+ * consolidated into a single call.
+ *
+ * Useful for things like "request update".
+ */
 export function consolidateCalls<Fn extends (...args: any[]) => void>(
   func: Fn
 ): (...args: Parameters<Fn>) => void {
-  // Return a function that will request `func` to be called in the next
-  // iteration of the event loop. If it gets called again before `func` was
-  // actually called, ignore the call.
-  // This ensures that multiple calls within the same event loop cycle get
-  // consolidated into a single call.
-  // Useful for things like "request update".
   let didSchedule = false;
 
   return (...args) => {
@@ -54,15 +60,19 @@ export function consolidateCalls<Fn extends (...args: any[]) => void>(
 
 export type TimeoutID = ReturnType<typeof setTimeout>;
 
+/**
+ * Schedule calls to func with a timer. If a previously scheduled call
+ * has not yet run, cancel it and let the new one override it.
+ *
+ * Returns a wrapped function that should be called instead of func.
+ *
+ * This is useful for calls triggered by events that can supersede
+ * previous calls; it avoids scheduling many redundant tasks.
+ */
 export function scheduleCalls<Fn extends (...args: any[]) => void>(
   func: Fn,
   timeout = 0
 ): (...args: Parameters<Fn>) => TimeoutID {
-  // Schedule calls to func with a timer. If a previously scheduled call
-  // has not yet run, cancel it and let the new one override it.
-  // Returns a wrapped function that should be called instead of func.
-  // This is useful for calls triggered by events that can supersede
-  // previous calls; it avoids scheduling many redundant tasks.
   let timeoutID: TimeoutID | null = null;
   return (...args) => {
     if (timeoutID !== null) {
@@ -76,13 +86,15 @@ export function scheduleCalls<Fn extends (...args: any[]) => void>(
   };
 }
 
+/**
+ * Return a wrapped function. If the function gets called before
+ * minTime (in ms) has elapsed since the last call, don't call
+ * the function.
+ */
 export function throttleCalls<Fn extends (...args: any[]) => void>(
   func: Fn,
   minTime = 0
 ): (...args: Parameters<Fn>) => TimeoutID | null {
-  // Return a wrapped function. If the function gets called before
-  // minTime (in ms) has elapsed since the last call, don't call
-  // the function.
   let lastTime = 0;
   let timeoutID: TimeoutID | null = null;
   return (...args) => {
@@ -156,19 +168,26 @@ export const arrowKeyDeltas = {
   ArrowRight: [1, 0],
 };
 
+/**
+ * Modulo with Python behavior for negative values of `v`
+ *
+ * Assumes `n` to be positive
+ */
 export function modulo(v: number, n: number) {
-  // Modulo with Python behavior for negative values of `v`
-  // Assumes `n` to be positive
   return v >= 0 ? v % n : ((v % n) + n) % n;
 }
 
+/**
+ * Return 1 if `v` is true-y, 0 if `v` is false-y
+ */
 export function boolInt(v: boolean) {
-  // Return 1 if `v` is true-y, 0 if `v` is false-y
   return v ? 1 : 0;
 }
 
+/**
+ * Like Python's reversed(seq) builtin
+ */
 export function* reversed<T>(seq: T[]) {
-  // Like Python's reversed(seq) builtin
   for (let i = seq.length - 1; i >= 0; i--) {
     yield seq[i];
   }
@@ -204,8 +223,10 @@ export function* range(start: number, stop?: number, step = 1) {
   }
 }
 
+/**
+ * After Python's itertools.chain()
+ */
 export function* chain<T>(...iterables: Iterable<T>[]) {
-  // After Python's itertools.chain()
   for (const iterable of iterables) {
     for (const item of iterable) {
       yield item;
@@ -213,9 +234,12 @@ export function* chain<T>(...iterables: Iterable<T>[]) {
   }
 }
 
+/**
+ * Cartesian product of input iterables. Equivalent to nested for-loops.
+ *
+ * After Python's itertools.product()
+ */
 export function* product<T>(...args: Iterable<T>[]): Generator<T[], void, unknown> {
-  // Cartesian product of input iterables.  Equivalent to nested for-loops.
-  // After Python's itertools.product()
   if (!args.length) {
     yield [];
     return;
@@ -236,8 +260,10 @@ export function* product<T>(...args: Iterable<T>[]): Generator<T[], void, unknow
   }
 }
 
+/**
+ * Return -1 when a < b, 1 when a > b, and 0 when a == b
+ */
 export function compare(a: number, b: number): -1 | 0 | 1 {
-  // Return -1 when a < b, 1 when a > b, and 0 when a == b
   return (+(a > b) - +(a < b)) as -1 | 0 | 1;
 }
 
@@ -307,10 +333,13 @@ export function getCharFromCodePoint(codePoint: number | undefined) {
   return codePoint !== undefined ? String.fromCodePoint(codePoint) : "";
 }
 
+/**
+ * Search for a 4-5 char hex string in the glyph name.
+ *
+ * Interpret the hex string as a unicode code point and convert to a
+ * character. Else, return an empty string.
+ */
 export function guessCharFromGlyphName(glyphName: string) {
-  // Search for a 4-5 char hex string in the glyph name.
-  // Interpret the hex string as a unicode code point and convert to a
-  // character. Else, return an empty string.
   const match = glyphName.match(/(^|[^0-9A-F])([0-9A-F]{4,5})($|[^0-9A-F])/);
   return match ? String.fromCodePoint(parseInt(match[2], 16)) : "";
 }
@@ -341,9 +370,11 @@ export function isActiveElementTypeable() {
   return false;
 }
 
+/**
+ * If the element element is part of a Web Component's Shadow DOM, take
+ * *its* active element, recursively.
+ */
 export function findNestedActiveElement(element?: Element | null): Element | null {
-  // If the element element is part of a Web Component's Shadow DOM, take
-  // *its* active element, recursively.
   if (!element) {
     element = document.activeElement;
   }
@@ -442,15 +473,19 @@ export function unionIndexSets(...indexSets: number[][]) {
   return [...new Set(indexSets.flat())].sort((a, b) => a - b);
 }
 
+/**
+ * Return a promise that resolves when `thenable` resolves before
+ * `timeout` ms have passed, or else gets rejected with an error.
+ * Example:
+ * ```ts
+ * try {
+ *   await withTimeout(somePromise, 1000);
+ * catch (error) {
+ *   // the promise timed out
+ * }
+ * ```
+ */
 export function withTimeout(thenable: Promise<any>, timeout: number) {
-  // Return a promise that resolves when `thenable` resolves before
-  // `timeout` ms have passed, or else gets rejected with an error.
-  // Example:
-  // try {
-  //   await withTimeout(somePromise, 1000);
-  // catch (error) {
-  //   // the promise timed out
-  // }
   return new Promise<void>((resolve, reject) => {
     const timerID = setTimeout(() => reject(new Error("timeout")), timeout);
     thenable.then(() => {
@@ -526,8 +561,10 @@ export function getGlyphNameExtension(glyphName: string) {
   return i >= 1 ? glyphName.slice(i) : "";
 }
 
+/**
+ * Return true if `obj` has no properties
+ */
 export function isObjectEmpty(obj: any) {
-  // Return true if `obj` has no properties
   for (const _ in obj) {
     return false;
   }
@@ -836,22 +873,18 @@ export function getCodePointFromGlyphItem(glyphItem: any) {
   return glyphItem.codePoints[0] || glyphItem.associatedCodePoints[0];
 }
 
-export function bisect_right<T>(a: T[], x: T) {
-  // Return the index where to insert item x in list a, assuming a is sorted.
-  //
-  // The return value i is such that all e in a[:i] have e <= x, and all e in
-  // a[i:] have e > x.  So if x already appears in the list, a.insert(i, x) will
-  // insert just after the rightmost x already there.
-  //
-  // Optional args lo (default 0) and hi (default len(a)) bound the
-  // slice of a to be searched.
-  //
-  // A custom key function can be supplied to customize the sort order.
-
+/**
+ * Return the index where to insert item x in list a, assuming a is sorted.
+ *
+ * The return value i is such that all e in a[:i] have e <= x, and all e in
+ * a[i:] have e > x.  So if x already appears in the list, a.insert(i, x) will
+ * insert just after the rightmost x already there.
+ *
+ * Optional args lo (default 0) and hi (default len(a)) bound the
+ * slice of a to be searched.
+ */
+export function bisect_right<T>(a: T[], x: T, lo = 0, hi = a.length) {
   // This is adapted from the Python implementation
-
-  let lo = 0;
-  let hi = a.length;
 
   while (lo < hi) {
     const mid = Math.floor((lo + hi) / 2);

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -705,6 +705,8 @@ export function areCustomDatasCompatible<
   return true;
 }
 
+// TODO: This should be temporary, in the future we should generate types
+//       for Guideline and others based on the python class definitions.
 export type Guideline = {
   x: number;
   y: number;

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -1,7 +1,9 @@
 import { strFromU8, strToU8, unzlibSync, zlibSync } from "fflate";
+import type { Point } from "./rectangle.ts";
 import { Transform } from "./transform.js";
+import { addItemwise } from "./var-funcs.js";
 
-export function objectsEqual(obj1, obj2) {
+export function objectsEqual(obj1: any, obj2: any) {
   // Shallow object compare. Arguments may be null or undefined
   if (!obj1 || !obj2) {
     return obj1 === obj2;
@@ -18,7 +20,7 @@ export function objectsEqual(obj1, obj2) {
   return true;
 }
 
-export function withSavedState(context, func) {
+export function withSavedState(context: CanvasRenderingContext2D, func: () => void) {
   context.save();
   try {
     func();
@@ -27,7 +29,9 @@ export function withSavedState(context, func) {
   }
 }
 
-export function consolidateCalls(func) {
+export function consolidateCalls<Fn extends (...args: any[]) => void>(
+  func: Fn
+): (...args: Parameters<Fn>) => void {
   // Return a function that will request `func` to be called in the next
   // iteration of the event loop. If it gets called again before `func` was
   // actually called, ignore the call.
@@ -48,13 +52,18 @@ export function consolidateCalls(func) {
   };
 }
 
-export function scheduleCalls(func, timeout = 0) {
+export type TimeoutID = ReturnType<typeof setTimeout>;
+
+export function scheduleCalls<Fn extends (...args: any[]) => void>(
+  func: Fn,
+  timeout = 0
+): (...args: Parameters<Fn>) => TimeoutID {
   // Schedule calls to func with a timer. If a previously scheduled call
   // has not yet run, cancel it and let the new one override it.
   // Returns a wrapped function that should be called instead of func.
   // This is useful for calls triggered by events that can supersede
   // previous calls; it avoids scheduling many redundant tasks.
-  let timeoutID = null;
+  let timeoutID: TimeoutID | null = null;
   return (...args) => {
     if (timeoutID !== null) {
       clearTimeout(timeoutID);
@@ -67,12 +76,15 @@ export function scheduleCalls(func, timeout = 0) {
   };
 }
 
-export function throttleCalls(func, minTime) {
+export function throttleCalls<Fn extends (...args: any[]) => void>(
+  func: Fn,
+  minTime = 0
+): (...args: Parameters<Fn>) => TimeoutID | null {
   // Return a wrapped function. If the function gets called before
   // minTime (in ms) has elapsed since the last call, don't call
   // the function.
   let lastTime = 0;
-  let timeoutID = null;
+  let timeoutID: TimeoutID | null = null;
   return (...args) => {
     if (timeoutID !== null) {
       clearTimeout(timeoutID);
@@ -94,7 +106,7 @@ export function throttleCalls(func, minTime) {
   };
 }
 
-export function parseCookies(str) {
+export function parseCookies(str: string) {
   // https://www.geekstrick.com/snippets/how-to-parse-cookies-in-javascript/
   if (!str.trim()) {
     return {};
@@ -103,21 +115,24 @@ export function parseCookies(str) {
     .split(";")
     .filter((s) => s)
     .map((v) => v.split("="))
-    .reduce((acc, v) => {
-      acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim());
-      return acc;
-    }, {});
+    .reduce(
+      (acc, v) => {
+        acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim());
+        return acc;
+      },
+      {} as Record<string, string>
+    );
 }
 
-export function capitalizeFirstLetter(s) {
+export function capitalizeFirstLetter(s: String) {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-export function hyphenatedToCamelCase(s) {
+export function hyphenatedToCamelCase(s: string) {
   return s.replace(/-([a-z])/g, (m) => m[1].toUpperCase());
 }
 
-export function hyphenatedToLabel(s) {
+export function hyphenatedToLabel(s: string) {
   return capitalizeFirstLetter(s).replaceAll("-", " ");
 }
 
@@ -141,25 +156,25 @@ export const arrowKeyDeltas = {
   ArrowRight: [1, 0],
 };
 
-export function modulo(v, n) {
+export function modulo(v: number, n: number) {
   // Modulo with Python behavior for negative values of `v`
   // Assumes `n` to be positive
   return v >= 0 ? v % n : ((v % n) + n) % n;
 }
 
-export function boolInt(v) {
+export function boolInt(v: boolean) {
   // Return 1 if `v` is true-y, 0 if `v` is false-y
   return v ? 1 : 0;
 }
 
-export function* reversed(seq) {
+export function* reversed<T>(seq: T[]) {
   // Like Python's reversed(seq) builtin
   for (let i = seq.length - 1; i >= 0; i--) {
     yield seq[i];
   }
 }
 
-export function* enumerate(iterable, start = 0) {
+export function* enumerate<T>(iterable: Iterable<T>, start = 0) {
   let i = start;
   for (const item of iterable) {
     yield [i, item];
@@ -167,13 +182,13 @@ export function* enumerate(iterable, start = 0) {
   }
 }
 
-export function* reversedEnumerate(seq) {
+export function* reversedEnumerate<T>(seq: T[]) {
   for (let i = seq.length - 1; i >= 0; i--) {
     yield [i, seq[i]];
   }
 }
 
-export function* range(start, stop, step = 1) {
+export function* range(start: number, stop?: number, step = 1) {
   if (stop === undefined) {
     stop = start;
     start = 0;
@@ -189,7 +204,7 @@ export function* range(start, stop, step = 1) {
   }
 }
 
-export function* chain(...iterables) {
+export function* chain<T>(...iterables: Iterable<T>[]) {
   // After Python's itertools.chain()
   for (const iterable of iterables) {
     for (const item of iterable) {
@@ -198,7 +213,7 @@ export function* chain(...iterables) {
   }
 }
 
-export function* product(...args) {
+export function* product<T>(...args: Iterable<T>[]): Generator<T[], void, unknown> {
   // Cartesian product of input iterables.  Equivalent to nested for-loops.
   // After Python's itertools.product()
   if (!args.length) {
@@ -221,23 +236,23 @@ export function* product(...args) {
   }
 }
 
-export function compare(a, b) {
+export function compare(a: number, b: number): -1 | 0 | 1 {
   // Return -1 when a < b, 1 when a > b, and 0 when a == b
-  return (a > b) - (a < b);
+  return (+(a > b) - +(a < b)) as -1 | 0 | 1;
 }
 
-export function valueInRange(min, v, max) {
+export function valueInRange(min: number, v: number, max: number) {
   return min <= v && v <= max;
 }
 
-export function parseSelection(selection) {
-  const result = {};
+export function parseSelection(selection: string[]) {
+  const result: Record<string, number[]> = {};
   for (const item of selection) {
     const [tp, index] = item.split("/");
     if (result[tp] === undefined) {
       result[tp] = [];
     }
-    result[tp].push(parseInt(index));
+    result[tp].push(parseInt(index, 10));
   }
   for (const indices of Object.values(result)) {
     // Ensure indices are sorted
@@ -246,7 +261,9 @@ export function parseSelection(selection) {
   return result;
 }
 
-export function makeUPlusStringFromCodePoint(codePoint) {
+export type Falsey = null | undefined | false | 0 | -0 | 0n | "";
+
+export function makeUPlusStringFromCodePoint(codePoint: number | Falsey) {
   if (codePoint && typeof codePoint != "number") {
     throw new Error(
       `codePoint argument must be a number or falsey; ${typeof codePoint} found`
@@ -257,7 +274,9 @@ export function makeUPlusStringFromCodePoint(codePoint) {
     : "";
 }
 
-export async function writeToClipboard(clipboardObject) {
+export async function writeToClipboard(
+  clipboardObject: ConstructorParameters<typeof ClipboardItem>[0]
+) {
   if (!clipboardObject) return;
 
   try {
@@ -265,13 +284,13 @@ export async function writeToClipboard(clipboardObject) {
   } catch (error) {
     console.log("Error while writing to clipboard, falling back to text/plain", error);
     // Write at least the plain/text MIME type to the clipboard
-    if (clipboardObject["text/plain"]) {
+    if (typeof clipboardObject["text/plain"] === "string") {
       await navigator.clipboard.writeText(await clipboardObject["text/plain"]);
     }
   }
 }
 
-export async function readFromClipboard(types, plainText = true) {
+export async function readFromClipboard(types: string[], plainText = true) {
   const clipboardContents = await navigator.clipboard.read();
   for (const item of clipboardContents) {
     for (const type of types) {
@@ -284,11 +303,11 @@ export async function readFromClipboard(types, plainText = true) {
   return undefined;
 }
 
-export function getCharFromCodePoint(codePoint) {
-  return codePoint != undefined ? String.fromCodePoint(codePoint) : "";
+export function getCharFromCodePoint(codePoint: number | undefined) {
+  return codePoint !== undefined ? String.fromCodePoint(codePoint) : "";
 }
 
-export function guessCharFromGlyphName(glyphName) {
+export function guessCharFromGlyphName(glyphName: string) {
   // Search for a 4-5 char hex string in the glyph name.
   // Interpret the hex string as a unicode code point and convert to a
   // character. Else, return an empty string.
@@ -296,7 +315,7 @@ export function guessCharFromGlyphName(glyphName) {
   return match ? String.fromCodePoint(parseInt(match[2], 16)) : "";
 }
 
-export async function fetchJSON(url, options) {
+export async function fetchJSON(url: string, options: Parameters<typeof fetch>[1]) {
   const response = await fetch(url, options);
   return await response.json();
 }
@@ -306,39 +325,40 @@ const nonTypeableInputTypes = new Set(["range", "checkbox", "radio", "button"]);
 export function isActiveElementTypeable() {
   const element = findNestedActiveElement(document.activeElement);
 
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
   if (element.isContentEditable) {
     return true;
   }
-  if (element.tagName.toLowerCase() === "textarea") {
+  if (element instanceof HTMLTextAreaElement) {
     return true;
   }
-  if (
-    element.tagName.toLowerCase() === "input" &&
-    !nonTypeableInputTypes.has(element.type)
-  ) {
+  if (element instanceof HTMLInputElement && !nonTypeableInputTypes.has(element.type)) {
     return true;
   }
   return false;
 }
 
-export function findNestedActiveElement(element) {
+export function findNestedActiveElement(element?: Element | null): Element | null {
   // If the element element is part of a Web Component's Shadow DOM, take
   // *its* active element, recursively.
   if (!element) {
     element = document.activeElement;
   }
-  return element.shadowRoot && element.shadowRoot.activeElement
+  return element?.shadowRoot?.activeElement
     ? findNestedActiveElement(element.shadowRoot.activeElement)
     : element;
 }
 
-export function fileNameExtension(name) {
+export function fileNameExtension(name: string) {
   return name.split(".").pop();
 }
 
 const ARRAY_EXTEND_CHUNK_SIZE = 1024;
 
-export function arrayExtend(thisArray, itemsArray) {
+export function arrayExtend<T>(thisArray: T[], itemsArray: T[]) {
   // arrayExtend() is meant as a JS version of Python's list.extend().
   // array.push(...items) has an implementation-defined upper limit
   // in terms of numbers of items (the call stack will overflow).
@@ -350,7 +370,7 @@ export function arrayExtend(thisArray, itemsArray) {
   }
 }
 
-export function rgbaToCSS(rgba) {
+export function rgbaToCSS(rgba: [number, number, number, number]) {
   const channels = rgba.slice(0, 3).map((channel) => Math.round(channel * 255));
   const alpha = rgba[3];
   if (alpha !== undefined && 0 <= alpha && alpha < 1) {
@@ -359,7 +379,9 @@ export function rgbaToCSS(rgba) {
   return `rgb(${channels.join(",")})`;
 }
 
-export function hexToRgba(hexColor) {
+export type HexColor = `#${string}`;
+
+export function hexToRgba(hexColor: HexColor): [number, number, number, number] {
   let c = hexColor.substring(1).split("");
   let r = [];
   if (/^#[A-Fa-f0-9]{8}$/.test(hexColor) || /^#[A-Fa-f0-9]{6}$/.test(hexColor)) {
@@ -378,10 +400,12 @@ export function hexToRgba(hexColor) {
   if (r.length === 3) {
     r.push(1);
   }
-  return r;
+  return r as [number, number, number, number];
 }
 
-export function rgbaToHex(rgba) {
+export function rgbaToHex(
+  rgba: [number, number, number] | [number, number, number, number]
+) {
   if (rgba.length != 3 && rgba.length != 4) {
     throw new Error("rgba argument has to have 3 or 4 items in array");
   }
@@ -396,13 +420,13 @@ export function rgbaToHex(rgba) {
   return `#${channels.join("")}`;
 }
 
-export function clamp(number, min, max) {
+export function clamp(number: number, min: number, max: number) {
   return Math.max(Math.min(number, max), min);
 }
 
 const _digitFactors = [1, 10, 100, 1000, 10000];
 
-export function round(number, nDigits = 0) {
+export function round(number: number, nDigits = 0) {
   if (nDigits === 0) {
     return Math.round(number);
   }
@@ -413,12 +437,12 @@ export function round(number, nDigits = 0) {
   return Math.round(number * factor) / factor;
 }
 
-export function unionIndexSets(...indexSets) {
+export function unionIndexSets(...indexSets: number[][]) {
   indexSets = indexSets.filter((item) => !!item);
   return [...new Set(indexSets.flat())].sort((a, b) => a - b);
 }
 
-export function withTimeout(thenable, timeout) {
+export function withTimeout(thenable: Promise<any>, timeout: number) {
   // Return a promise that resolves when `thenable` resolves before
   // `timeout` ms have passed, or else gets rejected with an error.
   // Example:
@@ -427,7 +451,7 @@ export function withTimeout(thenable, timeout) {
   // catch (error) {
   //   // the promise timed out
   // }
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     const timerID = setTimeout(() => reject(new Error("timeout")), timeout);
     thenable.then(() => {
       clearTimeout(timerID);
@@ -436,9 +460,9 @@ export function withTimeout(thenable, timeout) {
   });
 }
 
-export function memoize(func) {
+export function memoize<Fn extends (...args: any[]) => any>(func: Fn): Fn {
   const cache = new Map();
-  return (...args) => {
+  return ((...args) => {
     const cacheKey = JSON.stringify(args);
     if (cache.has(cacheKey)) {
       return cache.get(cacheKey);
@@ -446,11 +470,11 @@ export function memoize(func) {
     const result = func(...args);
     cache.set(cacheKey, result);
     return result;
-  };
+  }) as Fn;
 }
 
-export function escapeHTMLCharacters(dangerousString) {
-  const encodedSymbolMap = {
+export function escapeHTMLCharacters(dangerousString: string) {
+  const encodedSymbolMap: Record<string, string> = {
     // '"': '&quot;',
     // '\'': '&#39;',
     "&": "&amp;",
@@ -464,7 +488,7 @@ export function escapeHTMLCharacters(dangerousString) {
   return safeCharacters.join("");
 }
 
-export function* zip(...args) {
+export function* zip(...args: Iterable<any>[]) {
   const iterators = args.map((arg) => iter(arg));
   while (true) {
     const results = iterators.map((it) => it.next());
@@ -478,13 +502,13 @@ export function* zip(...args) {
   }
 }
 
-export function* iter(iterable) {
+export function* iter<T>(iterable: Iterable<T>) {
   for (const item of iterable) {
     yield item;
   }
 }
 
-export function splitGlyphNameExtension(glyphName, separator = ".") {
+export function splitGlyphNameExtension(glyphName: string, separator = ".") {
   const separatorIndex = glyphName.indexOf(separator);
   const baseGlyphName =
     separatorIndex >= 1 ? glyphName.slice(0, separatorIndex) : glyphName;
@@ -492,17 +516,17 @@ export function splitGlyphNameExtension(glyphName, separator = ".") {
   return [baseGlyphName, extension];
 }
 
-export function getBaseGlyphName(glyphName) {
+export function getBaseGlyphName(glyphName: string) {
   const i = glyphName.indexOf(".");
   return i >= 1 ? glyphName.slice(0, i) : glyphName;
 }
 
-export function getGlyphNameExtension(glyphName) {
+export function getGlyphNameExtension(glyphName: string) {
   const i = glyphName.lastIndexOf(".");
   return i >= 1 ? glyphName.slice(i) : "";
 }
 
-export function isObjectEmpty(obj) {
+export function isObjectEmpty(obj: any) {
   // Return true if `obj` has no properties
   for (const _ in obj) {
     return false;
@@ -510,7 +534,10 @@ export function isObjectEmpty(obj) {
   return true;
 }
 
-export async function timeIt(func, label) {
+export async function timeIt<Fn extends () => any>(
+  func: Fn,
+  label: string
+): Promise<ReturnType<Fn>> {
   const t = performance.now();
   const returnValue = await func();
   const elapsed = round(performance.now() - t, 1);
@@ -518,17 +545,17 @@ export async function timeIt(func, label) {
   return returnValue;
 }
 
-export function base64ToBytes(base64) {
+export function base64ToBytes(base64: string) {
   const binString = atob(base64);
-  return Uint8Array.from(binString, (m) => m.codePointAt(0));
+  return Uint8Array.from(binString, (m) => m.codePointAt(0) as number);
 }
 
-export function bytesToBase64(bytes) {
+export function bytesToBase64(bytes: Iterable<number>) {
   const binString = String.fromCodePoint(...bytes);
   return btoa(binString);
 }
 
-export function loadURLFragment(fragment) {
+export function loadURLFragment(fragment: string) {
   if (fragment[0] != "#") {
     throw new Error("assert -- invalid fragment");
   }
@@ -539,17 +566,21 @@ export function loadURLFragment(fragment) {
   }
 }
 
-export function dumpURLFragment(obj) {
+export function dumpURLFragment(obj: any) {
   return "#" + bytesToBase64(zlibSync(strToU8(JSON.stringify(obj))));
 }
 
 export function readObjectFromURLFragment() {
+  // @ts-ignore Typescript complains that window.location is missing some
+  // URL properties, but none of those matter for turning it in to one.
   const url = new URL(window.location);
   return url.hash ? loadURLFragment(url.hash) : {};
 }
 
-export function writeObjectToURLFragment(obj, replace = false) {
+export function writeObjectToURLFragment(obj: any, replace = false) {
   const newFragment = dumpURLFragment(obj);
+  // @ts-ignore Typescript complains that window.location is missing some
+  // URL properties, but none of those matter for turning it in to one.
   const url = new URL(window.location);
   if (url.hash === newFragment) {
     return;
@@ -562,7 +593,8 @@ export function writeObjectToURLFragment(obj, replace = false) {
   }
 }
 
-export function areGuidelinesCompatible(parents) {
+// TODO: proper typing for glyphs
+export function areGuidelinesCompatible(parents: any[]) {
   const referenceGuidelines = parents[0].guidelines;
   if (!referenceGuidelines) {
     return false;
@@ -584,7 +616,8 @@ export function areGuidelinesCompatible(parents) {
   return true;
 }
 
-export function areCustomDatasCompatible(parents) {
+// TODO: proper typing for glyphs
+export function areCustomDatasCompatible(parents: any[]) {
   const referenceCustomData = parents[0].customData;
   if (!referenceCustomData) {
     return false;
@@ -615,9 +648,17 @@ export function areCustomDatasCompatible(parents) {
   return true;
 }
 
+export type Guideline = {
+  x: number;
+  y: number;
+  angle: number;
+  locked?: boolean;
+  name?: string;
+};
+
 const identityGuideline = { x: 0, y: 0, angle: 0 };
 
-export function normalizeGuidelines(guidelines, resetLocked = false) {
+export function normalizeGuidelines(guidelines: Guideline[], resetLocked = false) {
   return guidelines.map((guideline) => {
     return {
       ...identityGuideline,
@@ -627,36 +668,57 @@ export function normalizeGuidelines(guidelines, resetLocked = false) {
   });
 }
 
-export function mapObject(obj, func) {
+type ObjectKey = string | number | symbol;
+
+export function mapObject<O extends {}>(
+  obj: O,
+  func: (entry: [keyof O, any]) => [ObjectKey, any]
+): any {
   // Return a copy of the object, with each [key, value] passed through `func`
-  return Object.fromEntries(Object.entries(obj).map(func));
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => func([k as keyof O, v]))
+  );
 }
 
-export function mapObjectKeys(obj, func) {
+export function mapObjectKeys<O extends {}>(
+  obj: O,
+  func: (key: keyof O) => ObjectKey
+): any {
   // Return a copy of the object, with each key passed through `func`
   return mapObject(obj, ([key, value]) => [func(key), value]);
 }
 
-export function mapObjectValues(obj, func) {
+export function mapObjectValues<O extends {}>(
+  obj: O,
+  func: (value: O[keyof O]) => any
+): any {
   // Return a copy of the object, with each value passed through `func`
   return mapObject(obj, ([key, value]) => [key, func(value)]);
 }
 
-export async function mapObjectValuesAsync(obj, func) {
+export async function mapObjectValuesAsync<O extends {}>(
+  obj: O,
+  func: (value: O[keyof O]) => any
+): Promise<any> {
   // Return a copy of the object, with each value passed through `func`
-  const result = {};
+  const result: any = {};
   for (const [key, value] of Object.entries(obj)) {
-    result[key] = await func(value);
+    result[key] = await func(value as O[keyof O]);
   }
   return result;
 }
 
-export function filterObject(obj, func) {
+export function filterObject<O extends {}>(
+  obj: O,
+  func: (key: keyof O, value: O[keyof O]) => boolean
+): Partial<O> {
   // Return a copy of the object containing the items for which `func(key, value)`
   // returns `true`.
   return Object.fromEntries(
-    Object.entries(obj).filter(([key, value]) => func(key, value))
-  );
+    Object.entries(obj).filter(([key, value]) =>
+      func(key as keyof O, value as O[keyof O])
+    )
+  ) as Partial<O>;
 }
 
 let _uniqueID = 1;
@@ -664,13 +726,13 @@ export function uniqueID() {
   return _uniqueID++;
 }
 
-export function assert(condition, message) {
+export function assert(condition: boolean, message: string): asserts condition {
   if (!condition) {
     throw new Error(`assert failed${message ? ` -- ${message}` : ""}`);
   }
 }
 
-export function pointCompareFunc(pointA, pointB) {
+export function pointCompareFunc(pointA: Point, pointB: Point) {
   let d = pointA.x - pointB.x;
   if (Math.abs(d) < 0.00000001) {
     d = pointA.y - pointB.y;
@@ -678,11 +740,11 @@ export function pointCompareFunc(pointA, pointB) {
   return d;
 }
 
-export function sleepAsync(ms) {
+export function sleepAsync(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function readFileOrBlobAsDataURL(fileOrBlob) {
+export function readFileOrBlobAsDataURL(fileOrBlob: File | Blob) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = (event) => resolve(reader.result);
@@ -691,13 +753,18 @@ export function readFileOrBlobAsDataURL(fileOrBlob) {
   });
 }
 
-export function colorizeImage(inputImage, color) {
+export function colorizeImage(
+  inputImage: HTMLImageElement,
+  color: CanvasRenderingContext2D["fillStyle"]
+) {
   const w = inputImage.naturalWidth;
   const h = inputImage.naturalHeight;
   const canvas = document.createElement("canvas");
   canvas.width = w;
   canvas.height = h;
   const context = canvas.getContext("2d");
+
+  assert(context !== null, "successfully acquired canvas rendering context");
 
   // First step, draw the image
   context.drawImage(inputImage, 0, 0, w, h);
@@ -712,6 +779,8 @@ export function colorizeImage(inputImage, color) {
 
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => {
+      assert(blob !== null, "successfully converted canvas to blob");
+
       const outputImage = new Image();
       outputImage.width = inputImage.width;
       outputImage.height = inputImage.height;
@@ -726,7 +795,9 @@ export function colorizeImage(inputImage, color) {
 }
 
 export class FocusKeeper {
-  get save() {
+  _focusedElement: Element | null = null;
+
+  get save(): (event: any) => void {
     // Return a bound method that can be used as an event handler
     return (event) => {
       this._focusedElement = findNestedActiveElement();
@@ -734,11 +805,14 @@ export class FocusKeeper {
   }
 
   restore() {
-    this._focusedElement?.focus();
+    // @ts-ignore typescript doesn't like that some Elements don't have `focus`
+    // but it doesn't matter since we do an optional invocation anyway so if it
+    // doesn't exist it won't cause any problems.
+    this._focusedElement?.focus?.();
   }
 }
 
-export function glyphMapToItemList(glyphMap) {
+export function glyphMapToItemList(glyphMap: Record<string, number[]>) {
   return Object.entries(glyphMap).map(([glyphName, codePoints]) => ({
     glyphName,
     codePoints,
@@ -746,7 +820,10 @@ export function glyphMapToItemList(glyphMap) {
   }));
 }
 
-export function getAssociatedCodePoints(glyphName, glyphMap) {
+export function getAssociatedCodePoints(
+  glyphName: string,
+  glyphMap: Record<string, number[]>
+) {
   return getBaseGlyphName(glyphName)
     .split("_")
     .filter((baseGlyphName) => baseGlyphName !== glyphName)
@@ -754,11 +831,12 @@ export function getAssociatedCodePoints(glyphName, glyphMap) {
     .filter((codePoint) => codePoint);
 }
 
-export function getCodePointFromGlyphItem(glyphItem) {
+// TODO: proper typing for glyphs
+export function getCodePointFromGlyphItem(glyphItem: any) {
   return glyphItem.codePoints[0] || glyphItem.associatedCodePoints[0];
 }
 
-export function bisect_right(a, x) {
+export function bisect_right<T>(a: T[], x: T) {
   // Return the index where to insert item x in list a, assuming a is sorted.
   //
   // The return value i is such that all e in a[:i] have e <= x, and all e in
@@ -787,11 +865,15 @@ export function bisect_right(a, x) {
   return lo;
 }
 
-export function isNumber(n) {
+export function isNumber(n: any) {
   return !isNaN(n) && typeof n === "number" && n !== Infinity && n !== -Infinity;
 }
 
-export function updateObject(obj, prop, value) {
+export function updateObject<O extends {}>(
+  obj: O,
+  prop: keyof O,
+  value: O[typeof prop]
+): O {
   obj = { ...obj };
   if (value === undefined) {
     delete obj[prop];
@@ -801,15 +883,15 @@ export function updateObject(obj, prop, value) {
   return obj;
 }
 
-export function longestCommonPrefix(strings) {
+export function longestCommonPrefix(strings: string[]) {
   if (!strings.length) {
     return "";
   }
 
   const firstString = strings[0];
-  let i;
+  let i = 0;
 
-  for (i = 0; ; i++) {
+  for (; ; i++) {
     const c = firstString[i];
     if (c === undefined) {
       break;
@@ -866,15 +948,18 @@ export const friendlyHttpStatus = {
   505: "HTTP Version Not Supported",
 };
 
-export function stringCompare(a, b) {
+export function stringCompare(a: string, b: string) {
   return a < b ? -1 : a === b ? 0 : 1;
 }
 
-export function deepCopyObject(obj) {
+export function deepCopyObject<O extends {}>(obj: O): O {
   return JSON.parse(JSON.stringify(obj));
 }
 
-export async function asyncMap(iterable, func) {
+export async function asyncMap<T>(
+  iterable: Iterable<T>,
+  func: (value: T) => T
+): Promise<T[]> {
   const result = [];
   for (const item of iterable) {
     result.push(await func(item));
@@ -882,17 +967,17 @@ export async function asyncMap(iterable, func) {
   return result;
 }
 
-export function parseDataURL(dataURL) {
+export function parseDataURL(dataURL: string) {
   const [header, data] = dataURL.split(",");
   const typeRegex = /data:(.+?\/.+?);/g;
   const match = typeRegex.exec(header);
-  const type = match[1];
-  if (!type) {
+  if (match === null || match.length < 1) {
     throw Error("invalid data URL");
   }
+  const type = match[1];
   return { type, data };
 }
 
-export function objectsEqualSerialized(a, b) {
+export function objectsEqualSerialized(a: any, b: any) {
   return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -640,8 +640,15 @@ export function writeObjectToURLFragment(obj: any, replace = false) {
   }
 }
 
-// TODO: proper typing for glyphs
-export function areGuidelinesCompatible(parents: any[]) {
+/**
+ * Checks whether the `guidelines` arrays of all `parents`
+ * are matching by comparing the `name` field of each item.
+ */
+export function areGuidelinesCompatible<
+  T extends {
+    guidelines: { name: string }[];
+  },
+>(parents: T[]) {
   const referenceGuidelines = parents[0].guidelines;
   if (!referenceGuidelines) {
     return false;
@@ -663,8 +670,11 @@ export function areGuidelinesCompatible(parents: any[]) {
   return true;
 }
 
-// TODO: proper typing for glyphs
-export function areCustomDatasCompatible(parents: any[]) {
+export function areCustomDatasCompatible<
+  T extends {
+    customData: any;
+  },
+>(parents: T[]) {
   const referenceCustomData = parents[0].customData;
   if (!referenceCustomData) {
     return false;

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -261,9 +261,21 @@ export function* product<T>(...args: Iterable<T>[]): Generator<T[], void, unknow
 }
 
 /**
+ * Compares two values which can either be numbers or strings.
+ *
+ * This uses the JavaScript `<` and `>` operators, which means that strings
+ * are compared by the values of their UTF-16 code units, starting at index
+ * zero, until a difference is found or one string runs out of code units
+ * (in which case the longer string is considered greater).
+ *
+ * Generally speaking, if strings are being sorted in order to be shown to
+ * the user then this function should not be used. Instead, use the function
+ * `String.localeCompare` or `Intl.Collator`, since they provide locale-aware
+ * collation and ordering, which the `<` and `>` operators do not.
+ *
  * Return -1 when a < b, 1 when a > b, and 0 when a == b
  */
-export function compare(a: number, b: number): -1 | 0 | 1 {
+export function compare<T extends number | string>(a: T, b: T): -1 | 0 | 1 {
   return (+(a > b) - +(a < b)) as -1 | 0 | 1;
 }
 
@@ -980,10 +992,6 @@ export const friendlyHttpStatus = {
   504: "Gateway Timeout",
   505: "HTTP Version Not Supported",
 };
-
-export function stringCompare(a: string, b: string) {
-  return a < b ? -1 : a === b ? 0 : 1;
-}
 
 export function deepCopyObject<O extends {}>(obj: O): O {
   return JSON.parse(JSON.stringify(obj));

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -299,15 +299,13 @@ export function parseSelection(selection: string[]) {
   return result;
 }
 
-export type Falsey = null | undefined | false | 0 | -0 | 0n | "";
-
-export function makeUPlusStringFromCodePoint(codePoint: number | Falsey) {
-  if (codePoint && typeof codePoint != "number") {
+export function makeUPlusStringFromCodePoint(codePoint: number | undefined) {
+  if (codePoint !== undefined && typeof codePoint !== "number") {
     throw new Error(
-      `codePoint argument must be a number or falsey; ${typeof codePoint} found`
+      `codePoint argument must be a number or undefined; ${typeof codePoint} found`
     );
   }
-  return typeof codePoint == "number"
+  return typeof codePoint === "number"
     ? "U+" + codePoint.toString(16).toUpperCase().padStart(4, "0")
     : "";
 }
@@ -684,7 +682,7 @@ export function areCustomDatasCompatible(parents: any[]) {
       }
 
       const vA = parent.customData[kA];
-      if (typeof vA == "object") {
+      if (typeof vA === "object") {
         const vB = referenceCustomData[kB];
         try {
           const _ = addItemwise(vA, vB);

--- a/src-js/fontra-core/src/var-glyph.js
+++ b/src-js/fontra-core/src/var-glyph.js
@@ -1,5 +1,5 @@
 import { getDecomposedIdentity } from "./transform.js";
-import { deepCopyObject, mapObjectValues, normalizeGuidelines, zip } from "./utils.js";
+import { deepCopyObject, mapObjectValues, normalizeGuidelines, zip } from "./utils.ts";
 import { VarPackedPath } from "./var-path.js";
 
 export class VariableGlyph {

--- a/src-js/fontra-core/src/var-model.js
+++ b/src-js/fontra-core/src/var-model.js
@@ -2,7 +2,7 @@
 
 import { VariationError } from "./errors.js";
 import { isSuperset } from "./set-ops.js";
-import { clamp, reversedEnumerate, round } from "./utils.js";
+import { clamp, reversedEnumerate, round } from "./utils.ts";
 import { addItemwise, mulScalar, subItemwise } from "./var-funcs.js";
 
 export class VariationModel {

--- a/src-js/fontra-core/src/var-path.js
+++ b/src-js/fontra-core/src/var-path.js
@@ -1,7 +1,7 @@
 import { Bezier } from "bezier-js";
 import { convexHull } from "./convex-hull.js";
 import { VariationError } from "./errors.js";
-import { centeredRect, pointInRect, rectFromPoints, updateRect } from "./rectangle.js";
+import { centeredRect, pointInRect, rectFromPoints, updateRect } from "./rectangle.ts";
 import {
   arrayExtend,
   assert,

--- a/src-js/fontra-core/src/var-path.js
+++ b/src-js/fontra-core/src/var-path.js
@@ -10,7 +10,7 @@ import {
   objectsEqualSerialized,
   range,
   reversed,
-} from "./utils.js";
+} from "./utils.ts";
 import VarArray from "./var-array.js";
 
 export const POINT_TYPE_OFF_CURVE_QUAD = "quad";

--- a/src-js/fontra-core/tests/test-change-recorder.js
+++ b/src-js/fontra-core/tests/test-change-recorder.js
@@ -3,7 +3,7 @@ import fs from "fs";
 
 import { recordChanges } from "@fontra/core/change-recorder.js";
 import { applyChange } from "@fontra/core/changes.js";
-import { deepCopyObject, enumerate } from "@fontra/core/utils.js";
+import { deepCopyObject, enumerate } from "@fontra/core/utils.ts";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 
 const testData = [

--- a/src-js/fontra-core/tests/test-changes.js
+++ b/src-js/fontra-core/tests/test-changes.js
@@ -9,7 +9,7 @@ import {
   matchChangePath,
   matchChangePattern,
 } from "@fontra/core/changes.js";
-import { deepCopyObject } from "@fontra/core/utils.js";
+import { deepCopyObject } from "@fontra/core/utils.ts";
 import { getTestData } from "./test-support.js";
 
 describe("applyChange Tests", () => {

--- a/src-js/fontra-core/tests/test-classes.js
+++ b/src-js/fontra-core/tests/test-classes.js
@@ -9,7 +9,7 @@ if (nodeMajor < 20) {
 }
 
 import coreClasses from "@fontra/core/classes.json" with { type: "json" };
-import { enumerate, range } from "@fontra/core/utils.js";
+import { enumerate, range } from "@fontra/core/utils.ts";
 import { Layer, StaticGlyph, VariableGlyph } from "@fontra/core/var-glyph.js";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 import { readRepoPathAsJSON } from "./test-support.js";

--- a/src-js/fontra-core/tests/test-cmap.js
+++ b/src-js/fontra-core/tests/test-cmap.js
@@ -6,7 +6,7 @@ import {
   makeCharacterMapFromGlyphMap,
   makeGlyphMapFromCharacterMap,
 } from "@fontra/core/cmap.js";
-import { enumerate } from "@fontra/core/utils.js";
+import { enumerate } from "@fontra/core/utils.ts";
 
 describe("characterMap tests", () => {
   const makeGlyphMapFromCharacterMap_testData = [

--- a/src-js/fontra-core/tests/test-glyph-controller.js
+++ b/src-js/fontra-core/tests/test-glyph-controller.js
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import { StaticGlyphController } from "@fontra/core/glyph-controller.js";
 import { getDecomposedIdentity } from "@fontra/core/transform.js";
-import { range } from "@fontra/core/utils.js";
+import { range } from "@fontra/core/utils.ts";
 import { StaticGlyph, VariableGlyph } from "@fontra/core/var-glyph.js";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 import { parametrize } from "./test-support.js";

--- a/src-js/fontra-core/tests/test-kerning-controller.js
+++ b/src-js/fontra-core/tests/test-kerning-controller.js
@@ -1,7 +1,7 @@
 import { applyChange } from "@fontra/core/changes.js";
 import { FontSourcesInstancer } from "@fontra/core/font-sources-instancer.js";
 import { KerningController } from "@fontra/core/kerning-controller.js";
-import { deepCopyObject } from "@fontra/core/utils.js";
+import { deepCopyObject } from "@fontra/core/utils.ts";
 import { expect } from "chai";
 import { parametrize } from "./test-support.js";
 

--- a/src-js/fontra-core/tests/test-path-changes.js
+++ b/src-js/fontra-core/tests/test-path-changes.js
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import fs from "fs";
 
 import { applyChange } from "@fontra/core/changes.js";
-import { deepCopyObject } from "@fontra/core/utils.js";
+import { deepCopyObject } from "@fontra/core/utils.ts";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 
 import { dirname, join } from "path";

--- a/src-js/fontra-core/tests/test-path-functions.js
+++ b/src-js/fontra-core/tests/test-path-functions.js
@@ -7,7 +7,7 @@ import {
   splitPathAtPointIndices,
 } from "@fontra/core/path-functions.js";
 import { PathHitTester } from "@fontra/core/path-hit-tester.js";
-import { enumerate } from "@fontra/core/utils.js";
+import { enumerate } from "@fontra/core/utils.ts";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 
 import { parametrize } from "./test-support.js";

--- a/src-js/fontra-core/tests/test-rectangle.js
+++ b/src-js/fontra-core/tests/test-rectangle.js
@@ -22,7 +22,7 @@ import {
   unionRect,
   updateRect,
   validateRect,
-} from "@fontra/core/rectangle.js";
+} from "@fontra/core/rectangle.ts";
 import { parametrize } from "./test-support.js";
 
 describe("pointInRect", () => {

--- a/src-js/fontra-core/tests/test-shaper.js
+++ b/src-js/fontra-core/tests/test-shaper.js
@@ -1,4 +1,4 @@
-import { assert, deepCopyObject } from "@fontra/core/utils.js";
+import { assert, deepCopyObject } from "@fontra/core/utils.ts";
 import { expect } from "chai";
 import { fileURLToPath } from "url";
 import { NodePath } from "./node-path.js";

--- a/src-js/fontra-core/tests/test-utils.js
+++ b/src-js/fontra-core/tests/test-utils.js
@@ -299,8 +299,8 @@ describe("makeUPlusStringFromCodePoint", () => {
   it("throws an exception when an invalid parameter is given", () => {
     expect(() => makeUPlusStringFromCodePoint("not-a-number")).to.throw();
   });
-  it("should not throw an exception for a falsy value", () => {
-    expect(() => makeUPlusStringFromCodePoint("")).to.not.throw();
+  it("should not throw an exception for undefined", () => {
+    expect(() => makeUPlusStringFromCodePoint(undefined)).to.not.throw();
   });
   it("make a number unicode hex", () => {
     expect(makeUPlusStringFromCodePoint(97)).equals("U+0061"); // a

--- a/src-js/fontra-core/tests/test-utils.js
+++ b/src-js/fontra-core/tests/test-utils.js
@@ -5,6 +5,7 @@ import {
   capitalizeFirstLetter,
   chain,
   clamp,
+  compare,
   consolidateCalls,
   dumpURLFragment,
   enumerate,
@@ -36,7 +37,6 @@ import {
   scheduleCalls,
   sleepAsync,
   splitGlyphNameExtension,
-  stringCompare,
   throttleCalls,
   withTimeout,
 } from "@fontra/core/utils.ts";
@@ -784,16 +784,19 @@ describe("longestCommonPrefix", () => {
   });
 });
 
-describe("stringCompare", () => {
+describe("compare", () => {
   const testData = [
     { a: "A", b: "A", result: 0 },
     { a: "A", b: "AA", result: -1 },
     { a: "A", b: "B", result: -1 },
     { a: "BB", b: "B", result: 1 },
     { a: "B", b: "A", result: 1 },
+    { a: 1, b: 1, result: 0 },
+    { a: 0, b: 1, result: -1 },
+    { a: 1, b: 0, result: 1 },
   ];
 
-  parametrize("stringCompare test", testData, (testCase) => {
-    expect(stringCompare(testCase.a, testCase.b)).to.equal(testCase.result);
+  parametrize("compare test", testData, (testCase) => {
+    expect(compare(testCase.a, testCase.b)).to.equal(testCase.result);
   });
 });

--- a/src-js/fontra-core/tests/test-utils.js
+++ b/src-js/fontra-core/tests/test-utils.js
@@ -39,7 +39,7 @@ import {
   stringCompare,
   throttleCalls,
   withTimeout,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { expect } from "chai";
 
 import { getTestData, parametrize } from "./test-support.js";

--- a/src-js/fontra-core/tests/test-var-glyph.js
+++ b/src-js/fontra-core/tests/test-var-glyph.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 import { getDecomposedIdentity } from "@fontra/core/transform.js";
-import { enumerate } from "@fontra/core/utils.js";
+import { enumerate } from "@fontra/core/utils.ts";
 import { StaticGlyph, VariableGlyph } from "@fontra/core/var-glyph.js";
 
 function makeTestGlyphObject() {

--- a/src-js/fontra-core/tests/test-var-path.js
+++ b/src-js/fontra-core/tests/test-var-path.js
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { parametrize } from "./test-support.js";
 
 import { Transform } from "@fontra/core/transform.js";
-import { enumerate } from "@fontra/core/utils.js";
+import { enumerate } from "@fontra/core/utils.ts";
 import VarArray from "@fontra/core/var-array.js";
 import {
   POINT_TYPE_OFF_CURVE_CUBIC,

--- a/src-js/fontra-webcomponents/src/custom-data-list.js
+++ b/src-js/fontra-webcomponents/src/custom-data-list.js
@@ -4,7 +4,7 @@ import { SimpleElement } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { ObservableController } from "@fontra/core/observable-object.js";
 import { labeledTextInput } from "@fontra/core/ui-utils.js";
-import { zip } from "@fontra/core/utils.js";
+import { zip } from "@fontra/core/utils.ts";
 import { dialogSetup } from "@fontra/web-components/modal-dialog.js";
 import { UIList } from "@fontra/web-components/ui-list.js";
 

--- a/src-js/fontra-webcomponents/src/glyph-cell-view.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell-view.js
@@ -6,7 +6,7 @@ import {
   symmetricDifference,
   union,
 } from "@fontra/core/set-ops.js";
-import { arrowKeyDeltas, assert, enumerate } from "@fontra/core/utils.js";
+import { arrowKeyDeltas, assert, enumerate } from "@fontra/core/utils.ts";
 import { GlyphCell } from "@fontra/web-components/glyph-cell.js";
 import { Accordion } from "@fontra/web-components/ui-accordion.js";
 

--- a/src-js/fontra-webcomponents/src/glyph-cell.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell.js
@@ -4,7 +4,7 @@ import * as html from "@fontra/core/html-utils.js";
 import { UnlitElement } from "@fontra/core/html-utils.js";
 import * as svg from "@fontra/core/svg-utils.js";
 import { Transform } from "@fontra/core/transform.js";
-import { assert, rgbaToCSS, throttleCalls } from "@fontra/core/utils.js";
+import { assert, rgbaToCSS, throttleCalls } from "@fontra/core/utils.ts";
 import { InlineSVG } from "./inline-svg.js";
 import { themeColorCSS } from "./theme-support.js";
 

--- a/src-js/fontra-webcomponents/src/glyph-search-list.js
+++ b/src-js/fontra-webcomponents/src/glyph-search-list.js
@@ -8,7 +8,7 @@ import {
   guessCharFromGlyphName,
   makeUPlusStringFromCodePoint,
   throttleCalls,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { GlyphSearchField } from "./glyph-search-field.js";
 import { UIList } from "./ui-list.js";
 

--- a/src-js/fontra-webcomponents/src/icon-button.js
+++ b/src-js/fontra-webcomponents/src/icon-button.js
@@ -1,6 +1,6 @@
 import * as html from "@fontra/core/html-utils.js";
 import { UnlitElement } from "@fontra/core/html-utils.js";
-import { FocusKeeper } from "@fontra/core/utils.js";
+import { FocusKeeper } from "@fontra/core/utils.ts";
 import { InlineSVG } from "./inline-svg.js";
 
 export class IconButton extends UnlitElement {

--- a/src-js/fontra-webcomponents/src/menu-bar.js
+++ b/src-js/fontra-webcomponents/src/menu-bar.js
@@ -1,6 +1,6 @@
 import * as html from "@fontra/core/html-utils.js";
 import { SimpleElement } from "@fontra/core/html-utils.js";
-import { sleepAsync } from "@fontra/core/utils.js";
+import { sleepAsync } from "@fontra/core/utils.ts";
 import { MenuPanel } from "./menu-panel.js";
 import { themeColorCSS } from "./theme-support.js";
 

--- a/src-js/fontra-webcomponents/src/menu-panel.js
+++ b/src-js/fontra-webcomponents/src/menu-panel.js
@@ -12,7 +12,7 @@ import {
   findNestedActiveElement,
   reversed,
   sleepAsync,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { InlineSVG } from "@fontra/web-components/inline-svg.js";
 import { themeColorCSS } from "./theme-support.js";
 

--- a/src-js/fontra-webcomponents/src/modal-dialog.js
+++ b/src-js/fontra-webcomponents/src/modal-dialog.js
@@ -1,7 +1,7 @@
 import * as html from "@fontra/core/html-utils.js";
 import { SimpleElement } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
-import { enumerate } from "@fontra/core/utils.js";
+import { enumerate } from "@fontra/core/utils.ts";
 
 export async function dialog(headline, message, buttonDefs, autoDismissTimeout) {
   const dialogContentElement = await dialogSetup(

--- a/src-js/fontra-webcomponents/src/range-slider.js
+++ b/src-js/fontra-webcomponents/src/range-slider.js
@@ -1,5 +1,5 @@
 import * as html from "@fontra/core/html-utils.js";
-import { clamp, round } from "@fontra/core/utils.js";
+import { clamp, round } from "@fontra/core/utils.ts";
 import { themeColorCSS } from "./theme-support.js";
 
 const colors = {

--- a/src-js/fontra-webcomponents/src/ui-accordion.js
+++ b/src-js/fontra-webcomponents/src/ui-accordion.js
@@ -1,6 +1,6 @@
 import * as html from "@fontra/core/html-utils.js";
 import { UnlitElement } from "@fontra/core/html-utils.js";
-import { FocusKeeper, enumerate } from "@fontra/core/utils.js";
+import { FocusKeeper, enumerate } from "@fontra/core/utils.ts";
 
 export class Accordion extends UnlitElement {
   static styles = `

--- a/src-js/fontra-webcomponents/src/ui-form.js
+++ b/src-js/fontra-webcomponents/src/ui-form.js
@@ -7,7 +7,7 @@ import {
   hyphenatedToCamelCase,
   round,
   scheduleCalls,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { RangeSlider } from "@fontra/web-components/range-slider.js";
 import "@fontra/web-components/rotary-control.js";
 

--- a/src-js/views-applicationsettings/src/panel-server-info.js
+++ b/src-js/views-applicationsettings/src/panel-server-info.js
@@ -1,7 +1,7 @@
 import * as html from "@fontra/core/html-utils.js";
 import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { MultiPanelBasePanel } from "@fontra/core/multi-panel.js";
-import { fetchJSON } from "@fontra/core/utils.js";
+import { fetchJSON } from "@fontra/core/utils.ts";
 
 const serverInfo = await fetchJSON("/serverinfo");
 

--- a/src-js/views-applicationsettings/src/panel-shortcuts.js
+++ b/src-js/views-applicationsettings/src/panel-shortcuts.js
@@ -13,7 +13,7 @@ import * as html from "@fontra/core/html-utils.js";
 import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { MultiPanelBasePanel } from "@fontra/core/multi-panel.js";
-import { commandKeyProperty, isMac } from "@fontra/core/utils.js";
+import { commandKeyProperty, isMac } from "@fontra/core/utils.ts";
 import { IconButton } from "@fontra/web-components/icon-button.js"; // required for the icon buttons
 import { dialog, message } from "@fontra/web-components/modal-dialog.js";
 

--- a/src-js/views-editor/src/cjk-design-frame.js
+++ b/src-js/views-editor/src/cjk-design-frame.js
@@ -1,4 +1,4 @@
-import { assert, range } from "@fontra/core/utils.js";
+import { assert, range } from "@fontra/core/utils.ts";
 import {
   glyphSelector,
   registerVisualizationLayerDefinition,

--- a/src-js/views-editor/src/edit-behavior-support.js
+++ b/src-js/views-editor/src/edit-behavior-support.js
@@ -1,4 +1,4 @@
-import { boolInt, modulo, reversed } from "@fontra/core/utils.js";
+import { boolInt, modulo, reversed } from "@fontra/core/utils.ts";
 
 // Or-able constants for rule definitions
 export const NIL = 1 << 0; // Does not exist

--- a/src-js/views-editor/src/edit-behavior.js
+++ b/src-js/views-editor/src/edit-behavior.js
@@ -11,7 +11,7 @@ import {
   parseSelection,
   reversed,
   unionIndexSets,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { copyBackgroundImage, copyComponent } from "@fontra/core/var-glyph.js";
 import * as vector from "@fontra/core/vector.js";
 import {

--- a/src-js/views-editor/src/edit-tools-knife.js
+++ b/src-js/views-editor/src/edit-tools-knife.js
@@ -1,6 +1,6 @@
 import { translate } from "@fontra/core/localization.js";
 import { slicePaths } from "@fontra/core/path-functions.js";
-import { mapObjectValues, zip } from "@fontra/core/utils.js";
+import { mapObjectValues, zip } from "@fontra/core/utils.ts";
 import * as vector from "@fontra/core/vector.js";
 import { constrainHorVerDiag } from "./edit-behavior.js";
 import { BaseTool, shouldInitiateDrag } from "./edit-tools-base.js";

--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -12,7 +12,7 @@ import {
   round,
   throttleCalls,
   updateObject,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { MenuItemDivider } from "@fontra/web-components/menu-panel.js";
 import { dialog, message } from "@fontra/web-components/modal-dialog.js";
 import { BaseTool, shouldInitiateDrag } from "./edit-tools-base.js";

--- a/src-js/views-editor/src/edit-tools-pen.js
+++ b/src-js/views-editor/src/edit-tools-pen.js
@@ -7,7 +7,7 @@ import {
 import { translate } from "@fontra/core/localization.js";
 import { insertHandles, insertPoint, scalePoint } from "@fontra/core/path-functions.js";
 import { isEqualSet } from "@fontra/core/set-ops.js";
-import { modulo, parseSelection } from "@fontra/core/utils.js";
+import { modulo, parseSelection } from "@fontra/core/utils.ts";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 import * as vector from "@fontra/core/vector.js";
 import { constrainHorVerDiag } from "./edit-behavior.js";

--- a/src-js/views-editor/src/edit-tools-pointer.js
+++ b/src-js/views-editor/src/edit-tools-pointer.js
@@ -12,7 +12,7 @@ import {
   offsetRect,
   pointInRect,
   rectSize,
-} from "@fontra/core/rectangle.js";
+} from "@fontra/core/rectangle.ts";
 import {
   difference,
   isSuperset,

--- a/src-js/views-editor/src/edit-tools-pointer.js
+++ b/src-js/views-editor/src/edit-tools-pointer.js
@@ -27,7 +27,7 @@ import {
   enumerate,
   parseSelection,
   range,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { copyBackgroundImage, copyComponent } from "@fontra/core/var-glyph.js";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 import * as vector from "@fontra/core/vector.js";

--- a/src-js/views-editor/src/edit-tools-power-ruler.js
+++ b/src-js/views-editor/src/edit-tools-power-ruler.js
@@ -1,5 +1,5 @@
 import { translate } from "@fontra/core/localization.js";
-import { range, round, throttleCalls } from "@fontra/core/utils.js";
+import { range, round, throttleCalls } from "@fontra/core/utils.ts";
 import * as vector from "@fontra/core/vector.js";
 import { constrainHorVerDiag } from "./edit-behavior.js";
 import { BaseTool } from "./edit-tools-base.js";

--- a/src-js/views-editor/src/edit-tools-shape.js
+++ b/src-js/views-editor/src/edit-tools-shape.js
@@ -1,4 +1,4 @@
-import * as rectangle from "@fontra/core/rectangle.js";
+import * as rectangle from "@fontra/core/rectangle.ts";
 import { commandKeyProperty, range } from "@fontra/core/utils.js";
 import { VarPackedPath, packContour } from "@fontra/core/var-path.js";
 import { BaseTool, shouldInitiateDrag } from "./edit-tools-base.js";

--- a/src-js/views-editor/src/edit-tools-shape.js
+++ b/src-js/views-editor/src/edit-tools-shape.js
@@ -1,5 +1,5 @@
 import * as rectangle from "@fontra/core/rectangle.ts";
-import { commandKeyProperty, range } from "@fontra/core/utils.js";
+import { commandKeyProperty, range } from "@fontra/core/utils.ts";
 import { VarPackedPath, packContour } from "@fontra/core/var-path.js";
 import { BaseTool, shouldInitiateDrag } from "./edit-tools-base.js";
 import {

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -28,7 +28,7 @@ import {
   rectScaleAroundCenter,
   rectSize,
   rectToArray,
-} from "@fontra/core/rectangle.js";
+} from "@fontra/core/rectangle.ts";
 import { SceneView } from "@fontra/core/scene-view.js";
 import { isSuperset } from "@fontra/core/set-ops.js";
 import { themeController } from "@fontra/core/theme-settings.js";

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -55,7 +55,7 @@ import {
   unionIndexSets,
   writeObjectToURLFragment,
   writeToClipboard,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { addItemwise, mulScalar, subItemwise } from "@fontra/core/var-funcs.js";
 import { StaticGlyph, VariableGlyph, copyComponent } from "@fontra/core/var-glyph.js";
 import { locationToString, makeSparseLocation } from "@fontra/core/var-model.js";

--- a/src-js/views-editor/src/panel-characters-glyphs.js
+++ b/src-js/views-editor/src/panel-characters-glyphs.js
@@ -10,7 +10,7 @@ import {
   range,
   round,
   throttleCalls,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { showMenu } from "@fontra/web-components/menu-panel.js";
 import {
   Accordion,

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -31,7 +31,7 @@ import {
   stringCompare,
   throttleCalls,
   updateObject,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { GlyphSource, Layer, StaticGlyph } from "@fontra/core/var-glyph.js";
 import {
   isLocationAtDefault,

--- a/src-js/views-editor/src/panel-designspace-navigation.js
+++ b/src-js/views-editor/src/panel-designspace-navigation.js
@@ -18,6 +18,7 @@ import {
 import {
   FocusKeeper,
   boolInt,
+  compare,
   enumerate,
   escapeHTMLCharacters,
   filterObject,
@@ -28,7 +29,6 @@ import {
   rgbaToCSS,
   round,
   scheduleCalls,
-  stringCompare,
   throttleCalls,
   updateObject,
 } from "@fontra/core/utils.ts";
@@ -1038,7 +1038,7 @@ export default class DesignspaceNavigationPanel extends Panel {
           break;
         case "by-source-name":
           sortFunc = (a, b) => {
-            return stringCompare(
+            return compare(
               varGlyphController.getSourceName(a),
               varGlyphController.getSourceName(b)
             );

--- a/src-js/views-editor/src/panel-glyph-note.js
+++ b/src-js/views-editor/src/panel-glyph-note.js
@@ -1,6 +1,6 @@
 import * as html from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
-import { throttleCalls } from "@fontra/core/utils.js";
+import { throttleCalls } from "@fontra/core/utils.ts";
 import Panel from "./panel.js";
 
 export default class GlyphNotePanel extends Panel {

--- a/src-js/views-editor/src/panel-glyph-search.js
+++ b/src-js/views-editor/src/panel-glyph-search.js
@@ -3,7 +3,7 @@ import {
   glyphSetsUIStyles,
 } from "@fontra/core/glyphsets-ui.js";
 import * as html from "@fontra/core/html-utils.js";
-import { glyphMapToItemList, isObjectEmpty } from "@fontra/core/utils.js";
+import { glyphMapToItemList, isObjectEmpty } from "@fontra/core/utils.ts";
 import "@fontra/web-components/glyph-search-list.js";
 import { Accordion } from "@fontra/web-components/ui-accordion.js";
 import Panel from "./panel.js";

--- a/src-js/views-editor/src/panel-reference-font.js
+++ b/src-js/views-editor/src/panel-reference-font.js
@@ -18,7 +18,7 @@ import {
   fileNameExtension,
   modulo,
   withTimeout,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { dialog, message } from "@fontra/web-components/modal-dialog.js";
 import "@fontra/web-components/range-slider.js";
 import { UIList } from "@fontra/web-components/ui-list.js";

--- a/src-js/views-editor/src/panel-related-glyphs.js
+++ b/src-js/views-editor/src/panel-related-glyphs.js
@@ -7,7 +7,7 @@ import { translate } from "@fontra/core/localization.js";
 import { unicodeMadeOf, unicodeUsedBy } from "@fontra/core/unicode-utils.js";
 import Panel from "./panel.js";
 
-import { getCharFromCodePoint, throttleCalls } from "@fontra/core/utils.js";
+import { getCharFromCodePoint, throttleCalls } from "@fontra/core/utils.ts";
 import { GlyphCellView } from "@fontra/web-components/glyph-cell-view.js";
 import { GlyphCell } from "@fontra/web-components/glyph-cell.js";
 import { showMenu } from "@fontra/web-components/menu-panel.js";

--- a/src-js/views-editor/src/panel-selection-info.js
+++ b/src-js/views-editor/src/panel-selection-info.js
@@ -17,7 +17,7 @@ import {
   round,
   splitGlyphNameExtension,
   throttleCalls,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { showMenu } from "@fontra/web-components/menu-panel.js";
 import { dialog } from "@fontra/web-components/modal-dialog.js";
 import { Form } from "@fontra/web-components/ui-form.js";

--- a/src-js/views-editor/src/panel-selection-info.js
+++ b/src-js/views-editor/src/panel-selection-info.js
@@ -2,7 +2,7 @@ import { applicationSettingsController } from "@fontra/core/application-settings
 import { recordChanges } from "@fontra/core/change-recorder.js";
 import * as html from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
-import { rectFromPoints, rectSize, unionRect } from "@fontra/core/rectangle.js";
+import { rectFromPoints, rectSize, unionRect } from "@fontra/core/rectangle.ts";
 import { compute, nameCapture } from "@fontra/core/simple-compute.js";
 import { getDecomposedIdentity } from "@fontra/core/transform.js";
 import {

--- a/src-js/views-editor/src/panel-text-entry.js
+++ b/src-js/views-editor/src/panel-text-entry.js
@@ -3,7 +3,7 @@ import { getGlyphInfoFromCodePoint } from "@fontra/core/glyph-data.js";
 import * as html from "@fontra/core/html-utils.js";
 import { features, languages, scripts } from "@fontra/core/opentype-tags.js";
 import { labeledCheckbox, labeledPopupSelect } from "@fontra/core/ui-utils.js";
-import { findNestedActiveElement } from "@fontra/core/utils.js";
+import { findNestedActiveElement } from "@fontra/core/utils.ts";
 import { showMenu } from "@fontra/web-components/menu-panel.js";
 import {
   Accordion,

--- a/src-js/views-editor/src/panel-transformation.js
+++ b/src-js/views-editor/src/panel-transformation.js
@@ -11,7 +11,7 @@ import {
   filterPathByPointIndices,
   getSelectionByContour,
 } from "@fontra/core/path-functions.js";
-import { rectCenter, rectSize } from "@fontra/core/rectangle.js";
+import { rectCenter, rectSize } from "@fontra/core/rectangle.ts";
 import { Transform } from "@fontra/core/transform.js";
 import {
   enumerate,

--- a/src-js/views-editor/src/panel-transformation.js
+++ b/src-js/views-editor/src/panel-transformation.js
@@ -20,7 +20,7 @@ import {
   range,
   reversed,
   zip,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { copyBackgroundImage, copyComponent } from "@fontra/core/var-glyph.js";
 import { VarPackedPath } from "@fontra/core/var-path.js";
 import { Form } from "@fontra/web-components/ui-form.js";

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -34,7 +34,7 @@ import {
   rectFromArray,
   rectRound,
   rectToArray,
-} from "@fontra/core/rectangle.js";
+} from "@fontra/core/rectangle.ts";
 import {
   difference,
   isSuperset,

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -56,7 +56,7 @@ import {
   reversed,
   withTimeout,
   zip,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { GlyphSource, Layer } from "@fontra/core/var-glyph.js";
 import { isLocationAtDefault } from "@fontra/core/var-model.js";
 import { VarPackedPath, packContour } from "@fontra/core/var-path.js";

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -32,7 +32,7 @@ import {
   range,
   reversed,
   valueInRange,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { normalizeLocation, unnormalizeLocation } from "@fontra/core/var-model.js";
 import * as vector from "@fontra/core/vector.js";
 

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -18,7 +18,7 @@ import {
   rectToPoints,
   sectRect,
   unionRect,
-} from "@fontra/core/rectangle.js";
+} from "@fontra/core/rectangle.ts";
 import { difference, isEqualSet, union, updateSet } from "@fontra/core/set-ops.js";
 import { MAX_UNICODE } from "@fontra/core/shaper.js";
 import { decomposedToTransform } from "@fontra/core/transform.js";

--- a/src-js/views-editor/src/sidebar.js
+++ b/src-js/views-editor/src/sidebar.js
@@ -1,6 +1,6 @@
 import * as html from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
-import { clamp, hyphenatedToLabel } from "@fontra/core/utils.js";
+import { clamp, hyphenatedToLabel } from "@fontra/core/utils.ts";
 
 export const MIN_SIDEBAR_WIDTH = 200;
 export const MAX_SIDEBAR_WIDTH = 500;

--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -1,6 +1,6 @@
 import { guessGlyphPlaceholderString } from "@fontra/core/glyph-data.js";
 import { translate } from "@fontra/core/localization.js";
-import { rectToPoints } from "@fontra/core/rectangle.js";
+import { rectToPoints } from "@fontra/core/rectangle.ts";
 import { difference, isSuperset, union } from "@fontra/core/set-ops.js";
 import { decomposedToTransform } from "@fontra/core/transform.js";
 import {

--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -13,7 +13,7 @@ import {
   round,
   unionIndexSets,
   withSavedState,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { subVectors } from "@fontra/core/vector.js";
 
 export const visualizationLayerDefinitions = [];

--- a/src-js/views-editor/src/visualization-layers.js
+++ b/src-js/views-editor/src/visualization-layers.js
@@ -1,4 +1,4 @@
-import { withSavedState } from "@fontra/core/utils.js";
+import { withSavedState } from "@fontra/core/utils.ts";
 import { mulScalar } from "@fontra/core/var-funcs.js";
 import { equalGlyphSelection } from "./scene-controller.js";
 

--- a/src-js/views-fontinfo/src/panel-axes.js
+++ b/src-js/views-fontinfo/src/panel-axes.js
@@ -11,7 +11,7 @@ import {
   labeledTextInput,
   setupSortableList,
 } from "@fontra/core/ui-utils.js";
-import { enumerate, range, zip } from "@fontra/core/utils.js";
+import { enumerate, range, zip } from "@fontra/core/utils.ts";
 import { piecewiseLinearMap } from "@fontra/core/var-model.js";
 import "@fontra/web-components/add-remove-buttons.js";
 import { IconButton } from "@fontra/web-components/icon-button.js"; // for <icon-button>

--- a/src-js/views-fontinfo/src/panel-base.js
+++ b/src-js/views-fontinfo/src/panel-base.js
@@ -6,7 +6,7 @@ import { UndoStack, reverseUndoRecord } from "@fontra/core/font-controller.js";
 import * as html from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { MultiPanelBasePanel } from "@fontra/core/multi-panel.js";
-import { commandKeyProperty, sleepAsync } from "@fontra/core/utils.js";
+import { commandKeyProperty, sleepAsync } from "@fontra/core/utils.ts";
 
 export class BaseInfoPanel extends MultiPanelBasePanel {
   constructor(viewController, panelElement) {

--- a/src-js/views-fontinfo/src/panel-cross-axis-mapping.js
+++ b/src-js/views-fontinfo/src/panel-cross-axis-mapping.js
@@ -8,7 +8,7 @@ import {
   labeledTextInput,
   setupSortableList,
 } from "@fontra/core/ui-utils.js";
-import { enumerate, range } from "@fontra/core/utils.js";
+import { enumerate, range } from "@fontra/core/utils.ts";
 import { mapAxesFromUserSpaceToSourceSpace } from "@fontra/core/var-model.js";
 import "@fontra/web-components/add-remove-buttons.js";
 import "@fontra/web-components/designspace-location.js";

--- a/src-js/views-fontinfo/src/panel-development-status-definitions.js
+++ b/src-js/views-fontinfo/src/panel-development-status-definitions.js
@@ -2,7 +2,7 @@ import { recordChanges } from "@fontra/core/change-recorder.js";
 import * as html from "@fontra/core/html-utils.js";
 import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
-import { enumerate, hexToRgba, range, rgbaToHex } from "@fontra/core/utils.js";
+import { enumerate, hexToRgba, range, rgbaToHex } from "@fontra/core/utils.ts";
 import { message } from "@fontra/web-components/modal-dialog.js";
 import { BaseInfoPanel } from "./panel-base.js";
 

--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -44,7 +44,7 @@ import { applicationSettingsController } from "@fontra/core/application-settings
 import * as html from "@fontra/core/html-utils.js";
 import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { ShaperController } from "@fontra/core/shaper-controller.js";
-import { compare, scheduleCalls } from "@fontra/core/utils.js";
+import { compare, scheduleCalls } from "@fontra/core/utils.ts";
 import { themeColorCSS } from "@fontra/web-components/theme-support.js";
 import { Tag } from "@lezer/highlight";
 import { BaseInfoPanel } from "./panel-base.js";

--- a/src-js/views-fontinfo/src/panel-sources.js
+++ b/src-js/views-fontinfo/src/panel-sources.js
@@ -24,7 +24,7 @@ import {
   range,
   round,
   sleepAsync,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import {
   locationToString,
   makeSparseLocation,

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -39,7 +39,7 @@ import {
   sleepAsync,
   writeObjectToURLFragment,
   writeToClipboard,
-} from "@fontra/core/utils.js";
+} from "@fontra/core/utils.ts";
 import { VariableGlyph } from "@fontra/core/var-glyph.js";
 import { ViewController } from "@fontra/core/view-controller.js";
 import { GlyphCellView } from "@fontra/web-components/glyph-cell-view.js";

--- a/src-js/views-fontoverview/src/panel-navigation.js
+++ b/src-js/views-fontoverview/src/panel-navigation.js
@@ -9,7 +9,7 @@ import { translate } from "@fontra/core/localization.js";
 import { ObservableController } from "@fontra/core/observable-object.js";
 import { difference, symmetricDifference, union } from "@fontra/core/set-ops.js";
 import { popupSelect } from "@fontra/core/ui-utils.js";
-import { scheduleCalls } from "@fontra/core/utils.js";
+import { scheduleCalls } from "@fontra/core/utils.ts";
 import { DesignspaceLocation } from "@fontra/web-components/designspace-location.js";
 import { GlyphSearchField } from "@fontra/web-components/glyph-search-field.js";
 import { Accordion } from "@fontra/web-components/ui-accordion.js";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "lib": ["es2021", "dom"],
+    "target": "es2015",
+    "paths": {
+      "*": ["./src-js/*"]
+    },
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["@types/emscripten"]
+  },
+  "include": ["./src-js/*/src/**/*", "./src-js/*/types/**/*.d.ts"],
+  "exclude": ["**/node_modules/**/*", "**/webpack*"],
+  "$schema": "https://www.schemastore.org/tsconfig"
+}


### PR DESCRIPTION
Adds a `tsconfig.json` so that `tsc` in the root directory will type check all `.ts` files inside `src-js`. Enabling checking of js via tsc (`"checkJs": true`) yields a ton of errors, most of which I'm sure are spurious and just present because it isn't sure about the types of everything.

Once a lot more stuff is converted to typescript it may make sense to enable js checking- and it might make sense to enable it and run `tsc` just to get a list of files that might be good candidates for conversion - but aside from that it's not really a problem that it's not enabled right now, since the first and foremost benefit of this change in my opinion is the improved interaction with tooling (editor completions mainly).

As a start, I've converted `rectangle.js` and `utils.js` to typescript. They're mostly completely typed, though some of the things that take glyph objects (or arrays thereof) in `utils.js` have them typed as `any` with a `TODO` comment about properly typing them in the future.

I've tried to separate this in to individually reviewable commits so the noise from changing all of the imports doesn't get in the way of the main changes.

If you have any questions, let me know.