### PR TITLE
add tsc precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,11 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+
+  - repo: local
+    hooks:
+      - id: run-tsc
+        name: Run `tsc` to type check all TypeScript files.
+        entry: tsc
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
Adds a precommit hook that runs `tsc` in order to make sure there are no type errors. I verified that this properly prevents the commit from going through if there are type errors in any `.ts` file. This requires that you have the npm dev dependencies properly installed (`npm install`).