### PR TITLE
[shaping] Fix conditional substitution behavior on invalid axis input

### DIFF
--- a/src-js/fontra-core/src/shaper-controller.js
+++ b/src-js/fontra-core/src/shaper-controller.js
@@ -352,7 +352,7 @@ export function prepareConditionalSubstitutions(
       conditionSets.map(({ conditions }) =>
         Object.fromEntries(
           conditions
-            .filter(({ name }) => !!axesByName[name])
+            .filter(({ name }) => !!axesByName[name]) // filter out non-existent axes
             .map(({ name, minValue, maxValue }) => {
               const axis = axesByName[name];
               const mapFunc = getMapFunc(name);

--- a/src-js/fontra-core/src/shaper-controller.js
+++ b/src-js/fontra-core/src/shaper-controller.js
@@ -320,7 +320,8 @@ function ensureNotdef(glyphOrder) {
   glyphOrder.unshift(".notdef");
 }
 
-function prepareConditionalSubstitutions(
+/* export only for testing */
+export function prepareConditionalSubstitutions(
   substitutions,
   fontAxes,
   fontAxesSourceSpace,
@@ -350,14 +351,19 @@ function prepareConditionalSubstitutions(
     rules: substitutions.rules.map(({ conditionSets, substitutions }) => [
       conditionSets.map(({ conditions }) =>
         Object.fromEntries(
-          conditions.map(({ name, minValue, maxValue }) => {
-            const axis = axesByName[name];
-            const mapFunc = getMapFunc(name);
-            return [
-              axis.tag,
-              [mapFunc(minValue ?? axis.minValue), mapFunc(maxValue ?? axis.maxValue)],
-            ];
-          })
+          conditions
+            .filter(({ name }) => !!axesByName[name])
+            .map(({ name, minValue, maxValue }) => {
+              const axis = axesByName[name];
+              const mapFunc = getMapFunc(name);
+              return [
+                axis.tag,
+                [
+                  mapFunc(minValue ?? axis.minValue),
+                  mapFunc(maxValue ?? axis.maxValue),
+                ],
+              ];
+            })
         )
       ),
       filterObject(

--- a/src-js/fontra-core/tests/test-shaper.js
+++ b/src-js/fontra-core/tests/test-shaper.js
@@ -9,7 +9,10 @@ import { buildShaperFont } from "build-shaper-font";
 
 import { guessDirectionFromCodePoints } from "@fontra/core/glyph-data.js";
 import { ObservableController } from "@fontra/core/observable-object.ts";
-import { ShaperController } from "@fontra/core/shaper-controller.js";
+import {
+  prepareConditionalSubstitutions,
+  ShaperController,
+} from "@fontra/core/shaper-controller.js";
 import {
   applyCursiveAttachments,
   applyKerning,
@@ -1926,6 +1929,96 @@ describe("test conditional substitutions with mapping", () => {
     });
     const glyphNames8 = glyphs8.map((g) => g.glyphname);
     expect(glyphNames8).to.deep.equal(["cent", "oslash", "fi.rvrn"]);
+  });
+});
+
+describe("prepareConditionalSubstitutions ", () => {
+  const axes = [
+    { name: "Weight", tag: "wght", minValue: 200, defaultValue: 400, maxValue: 700 },
+  ];
+  const glyphMap = { "A": [], "A.alt": [] };
+
+  it("prepareConditionalSubstitutions with correct inputs", () => {
+    const substitutions = {
+      featureTags: ["rvrn"],
+      rules: [
+        {
+          name: "Weight rule",
+          conditionSets: [
+            { conditions: [{ name: "Weight", minValue: 200, maxValue: 400 }] },
+          ],
+          substitutions: { A: "A.alt" },
+        },
+      ],
+    };
+
+    const substForBuildShaperFont = prepareConditionalSubstitutions(
+      substitutions,
+      axes,
+      axes,
+      glyphMap
+    );
+
+    expect(substForBuildShaperFont).to.deep.equal({
+      featureTags: ["rvrn"],
+      rules: [[[{ wght: [200, 400] }], { A: "A.alt" }]],
+    });
+  });
+
+  it("prepareConditionalSubstitutions with incorrect axis inputs", () => {
+    const substitutions = {
+      featureTags: ["rvrn"],
+      rules: [
+        {
+          name: "Weight rule",
+          conditionSets: [
+            // unknown axis name (misspelled)
+            { conditions: [{ name: "weight", minValue: 200, maxValue: 400 }] },
+          ],
+          substitutions: { A: "A.alt" },
+        },
+      ],
+    };
+
+    const substForBuildShaperFont = prepareConditionalSubstitutions(
+      substitutions,
+      axes,
+      axes,
+      glyphMap
+    );
+
+    expect(substForBuildShaperFont).to.deep.equal({
+      featureTags: ["rvrn"],
+      rules: [[[{}], { A: "A.alt" }]],
+    });
+  });
+
+  it("prepareConditionalSubstitutions with incorrect glyph name inputs", () => {
+    const substitutions = {
+      featureTags: ["rvrn"],
+      rules: [
+        {
+          name: "Weight rule",
+          conditionSets: [
+            { conditions: [{ name: "Weight", minValue: 200, maxValue: 400 }] },
+          ],
+          // non-existent glyph name
+          substitutions: { A: "B" },
+        },
+      ],
+    };
+
+    const substForBuildShaperFont = prepareConditionalSubstitutions(
+      substitutions,
+      axes,
+      axes,
+      glyphMap
+    );
+
+    expect(substForBuildShaperFont).to.deep.equal({
+      featureTags: ["rvrn"],
+      rules: [[[{ wght: [200, 400] }], {}]],
+    });
   });
 });
 


### PR DESCRIPTION
If the conditional substitution rules mention a non-existent axis, gracefully drop the rule instead of crashing. This improves behavior when fed invalid rule data.