### PR TITLE
Allow hex code points in glyph search

### DIFF
--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -72,7 +72,7 @@ export class GlyphOrganizer {
     // by U+ or 0x, look for the character this hex code point represents
     const literalHexSearchItems = searchStrings
       .map((item) => {
-        const match = item.match(/(?<=U\+|0x|^)([0-9A-F]{2,5})$/i);
+        const match = item.match(/(?<=U\+|0x)([0-9A-F]{2,5})$/i);
         return match ? parseInt(match[0], 16) : undefined;
       })
       .filter((item) => item);

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -72,7 +72,7 @@ export class GlyphOrganizer {
     // by U+ or 0x, look for the character this hex code point represents
     const literalHexSearchItems = searchStrings
       .map((item) => {
-        const match = item.match(/(?<=U\+|0x|^)([0-9A-Fa-f]{4,5})$/);
+        const match = item.match(/(?<=U\+|0x|^)([0-9A-Fa-f]{2,5})$/);
         return match ? parseInt(match[0], 16) : undefined;
       })
       .filter((item) => item);

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -64,23 +64,37 @@ export class GlyphOrganizer {
   setSearchString(searchString) {
     const searchStrings = searchString.split(/\s+/).filter((item) => item.length);
 
-    const hexSearchItems = searchStrings
+    const singleCharSearchItems = searchStrings
       .filter((item) => [...item].length === 1) // num chars, not utf16 units!
+      .map((item) => item.codePointAt(0));
+
+    // If a search item is a 4-5 characters long hex string, optionally prefixed
+    // by U+ or 0x, look for the character this hex code point represents
+    const literalHexSearchItems = searchStrings
       .map((item) => {
-        const hexCodePoint = item
-          .codePointAt(0)
-          .toString(16)
-          .toUpperCase()
-          .padStart(4, "0");
-        // Only match if there are no hex digits before and after
-        return new RegExp(`([^0-9A-F]|^)${hexCodePoint}([^0-9A-F]|$)`);
-      });
+        const match = item.match(/(?<=U\+|0x|^)([0-9A-Fa-f]{4,5})$/);
+        return match ? parseInt(match[0], 16) : undefined;
+      })
+      .filter((item) => item);
 
-    const searchItems = searchStrings
-      .map((s) => RegExp.escape(s))
-      .concat(hexSearchItems);
+    // If a search item is a single character, search for glyph names that contain
+    // the character's codepoint as an uppercase hex string. For example, if a search
+    // item is 'A', then search for glyph names containing '0041'
+    const hexSearchItems = singleCharSearchItems.map((codePoint) => {
+      const hexCodePoint = codePoint.toString(16).toUpperCase().padStart(4, "0");
+      // Only match if there are no hex digits before and after
+      return new RegExp(`([^0-9A-F]|^)${hexCodePoint}([^0-9A-F]|$)`);
+    });
 
-    this._glyphNamesListFilterFunc = (item) => glyphFilterFunc(item, searchItems);
+    const regexSearchItems = [
+      ...searchStrings.map((s) => new RegExp(RegExp.escape(s))),
+      ...hexSearchItems,
+    ];
+
+    const codePointSearchItems = [...singleCharSearchItems, ...literalHexSearchItems];
+
+    this._glyphNamesListFilterFunc = (item) =>
+      glyphFilterFunc(item, regexSearchItems, codePointSearchItems);
   }
 
   setGroupByKeys(groupByKeys) {
@@ -153,22 +167,20 @@ function compareGroupInfo(groupByEntryA, groupByEntryB) {
   return 0;
 }
 
-function glyphFilterFunc(item, searchItems) {
-  if (!searchItems.length) {
+function glyphFilterFunc(item, regexSearchItems, codePointSearchItems) {
+  if (!regexSearchItems.length && !codePointSearchItems.length) {
     return true;
   }
-  for (const searchItem of searchItems) {
-    if (item.glyphName.search(searchItem) >= 0) {
+
+  for (const regex of regexSearchItems) {
+    if (item.glyphName.search(regex) >= 0) {
       return true;
     }
-    if (item.codePoints[0] !== undefined) {
-      const char = String.fromCodePoint(item.codePoints[0]);
-      if (searchItem === char) {
-        return true;
-      }
-    }
   }
-  return false;
+
+  return item.codePoints.some((codePoint) => {
+    return codePointSearchItems.some((codePointItem) => codePointItem == codePoint);
+  });
 }
 
 function glyphItemSortFunc(item1, item2) {

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -62,8 +62,9 @@ export class GlyphOrganizer {
   }
 
   setSearchString(searchString) {
-    const searchItems = searchString.split(/\s+/).filter((item) => item.length);
-    const hexSearchItems = searchItems
+    const searchStrings = searchString.split(/\s+/).filter((item) => item.length);
+
+    const hexSearchItems = searchStrings
       .filter((item) => [...item].length === 1) // num chars, not utf16 units!
       .map((item) => {
         const hexCodePoint = item
@@ -74,7 +75,11 @@ export class GlyphOrganizer {
         // Only match if there are no hex digits before and after
         return new RegExp(`([^0-9A-F]|^)${hexCodePoint}([^0-9A-F]|$)`);
       });
-    searchItems.push(...hexSearchItems);
+
+    const searchItems = searchStrings
+      .map((s) => RegExp.escape(s))
+      .concat(hexSearchItems);
+
     this._glyphNamesListFilterFunc = (item) => glyphFilterFunc(item, searchItems);
   }
 

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -1,4 +1,8 @@
-import { getGlyphInfoFromCodePoint, getGlyphInfoFromGlyphName } from "./glyph-data.js";
+import {
+  getGlyphInfoFromCodePoint,
+  getGlyphInfoFromGlyphName,
+  getSuggestedGlyphName,
+} from "./glyph-data.js";
 import { block, script, scriptNames } from "./unicode-scripts-blocks.js";
 import {
   capitalizeFirstLetter,
@@ -93,6 +97,7 @@ export class GlyphOrganizer {
 
     const codePointSearchItems = [...singleCharSearchItems, ...literalHexSearchItems];
 
+    this._codePointSearchItems = codePointSearchItems;
     this._glyphNamesListFilterFunc = (item) =>
       glyphFilterFunc(item, regexSearchItems, codePointSearchItems);
   }
@@ -114,8 +119,26 @@ export class GlyphOrganizer {
     return glyphs;
   }
 
-  filterGlyphs(glyphs) {
-    return glyphs.filter(this._glyphNamesListFilterFunc);
+  filterGlyphs(glyphs, appendUndefinedCharacters = false) {
+    const filteredGlyphs = glyphs.filter(this._glyphNamesListFilterFunc);
+
+    if (appendUndefinedCharacters) {
+      for (const codePoint of this._codePointSearchItems) {
+        if (
+          filteredGlyphs.some((glyphItem) => glyphItem.codePoints.includes(codePoint))
+        ) {
+          continue;
+        }
+
+        filteredGlyphs.push({
+          glyphName: getSuggestedGlyphName(codePoint),
+          codePoints: [codePoint],
+          associatedCodePoints: [],
+        });
+      }
+    }
+
+    return filteredGlyphs;
   }
 
   groupGlyphs(glyphs) {

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -83,7 +83,9 @@ export class GlyphOrganizer {
 
     // If a search item is a single character, search for glyph names that contain
     // the character's codepoint as an uppercase hex string. For example, if a search
-    // item is 'A', then search for glyph names containing '0041'
+    // item is 'A', then search for glyph names containing '0041'.
+    // This functionality was requested by CJK designers who use hex code points in
+    // variable component glyphs.
     const hexSearchItems = singleCharSearchItems.map((codePoint) => {
       const hexCodePoint = codePoint.toString(16).toUpperCase().padStart(4, "0");
       // Only match if there are no hex digits before and after

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -72,8 +72,8 @@ export class GlyphOrganizer {
       .filter((item) => [...item].length === 1) // num chars, not utf16 units!
       .map((item) => item.codePointAt(0));
 
-    // If a search item is a 4-5 characters long hex string, optionally prefixed
-    // by U+ or 0x, look for the character this hex code point represents
+    // If a search item is a 2-5 characters long hex string, prefixed by U+ or 0x,
+    // look for the character this hex code point represents
     const literalHexSearchItems = searchStrings
       .map((item) => {
         const match = item.match(/(?<=U\+|0x)([0-9A-F]{2,5})$/i);

--- a/src-js/fontra-core/src/glyph-organizer.js
+++ b/src-js/fontra-core/src/glyph-organizer.js
@@ -72,7 +72,7 @@ export class GlyphOrganizer {
     // by U+ or 0x, look for the character this hex code point represents
     const literalHexSearchItems = searchStrings
       .map((item) => {
-        const match = item.match(/(?<=U\+|0x|^)([0-9A-Fa-f]{2,5})$/);
+        const match = item.match(/(?<=U\+|0x|^)([0-9A-F]{2,5})$/i);
         return match ? parseInt(match[0], 16) : undefined;
       })
       .filter((item) => item);

--- a/src-js/fontra-webcomponents/src/glyph-search-list.js
+++ b/src-js/fontra-webcomponents/src/glyph-search-list.js
@@ -59,17 +59,14 @@ export class GlyphSearchList extends SimpleElement {
         title: "glyph name",
         width: "10em",
         isIdentifierKey: true,
-        cellFactory: (item, description) => {
-          const glyphName = item.glyphName;
-          return !this._fontGlyphMap || this._fontGlyphMap[glyphName]
-            ? glyphName
-            : html.span({ class: "dimmed" }, [glyphName]);
-        },
+        get: (item) => item.glyphName,
+        cellFactory: (item, description) => this._cellFactory(item, description),
       },
       {
         key: "unicode",
         width: "fit-content",
         get: (item) => item.codePoints.map(makeUPlusStringFromCodePoint).join(","),
+        cellFactory: (item, description) => this._cellFactory(item, description),
       },
     ];
     const glyphNamesList = new UIList();
@@ -96,6 +93,14 @@ export class GlyphSearchList extends SimpleElement {
       this.dispatchEvent(event);
     });
     return glyphNamesList;
+  }
+
+  _cellFactory(item, description) {
+    const glyphName = item.glyphName;
+    const valueString = description.get(item);
+    return !this._fontGlyphMap || this._fontGlyphMap[glyphName]
+      ? valueString
+      : html.span({ class: "dimmed" }, [valueString]);
   }
 
   focusSearchField() {

--- a/src-js/fontra-webcomponents/src/glyph-search-list.js
+++ b/src-js/fontra-webcomponents/src/glyph-search-list.js
@@ -129,6 +129,15 @@ export class GlyphSearchList extends SimpleElement {
     this.requestUpdate();
   }
 
+  get allowUnknownGlyphSearchResults() {
+    return this._allowUnknownGlyphSearchResults ?? false;
+  }
+
+  set allowUnknownGlyphSearchResults(allowUnknownGlyphSearchResults) {
+    this._allowUnknownGlyphSearchResults = allowUnknownGlyphSearchResults;
+    this.requestUpdate();
+  }
+
   updateGlyphNamesListContent() {
     this.glyphOrganizer.setSearchString(this.searchField.searchString);
     this.glyphsListItems = this.glyphOrganizer.sortGlyphs(
@@ -138,7 +147,10 @@ export class GlyphSearchList extends SimpleElement {
   }
 
   _setFilteredGlyphNamesListContent() {
-    const filteredGlyphItems = this.glyphOrganizer.filterGlyphs(this.glyphsListItems);
+    const filteredGlyphItems = this.glyphOrganizer.filterGlyphs(
+      this.glyphsListItems,
+      this.allowUnknownGlyphSearchResults
+    );
     this.glyphNamesList.setItems(filteredGlyphItems);
     this.glyphNamesList.hidden = filteredGlyphItems.length === 0;
   }

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3061,6 +3061,7 @@ export class EditorController extends ViewController {
     if (!showOnlyGlyphsInFont && !isObjectEmpty(this.sceneSettings.combinedGlyphMap)) {
       glyphSearch.glyphMap = this.sceneSettings.combinedGlyphMap;
       glyphSearch.fontGlyphMap = this.fontController.glyphMap;
+      glyphSearch.allowUnknownGlyphSearchResults = true;
     } else {
       glyphSearch.glyphMap = this.fontController.glyphMap;
     }

--- a/src-js/views-editor/src/panel-glyph-search.js
+++ b/src-js/views-editor/src/panel-glyph-search.js
@@ -33,6 +33,7 @@ export default class GlyphSearchPanel extends Panel {
     );
     this.editorController.fontController.ensureInitialized.then(() => {
       this.glyphSearch.glyphMap = this.editorController.fontController.glyphMap;
+      this.glyphSearch.allowUnknownGlyphSearchResults = true;
     });
 
     this.editorController.sceneSettingsController.addKeyListener(

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -350,7 +350,7 @@ export class FontOverviewController extends ViewController {
       combinedItemList = this.glyphOrganizer.sortGlyphs(combinedItemList);
     }
 
-    const glyphItemList = this.glyphOrganizer.filterGlyphs(combinedItemList);
+    const glyphItemList = this.glyphOrganizer.filterGlyphs(combinedItemList, true);
     const glyphSections = this.glyphOrganizer.groupGlyphs(glyphItemList);
     this.glyphCellView.setGlyphSections(glyphSections);
 


### PR DESCRIPTION
This fixes #2606.

- Allow glyph search (font overview, editor) by hex unicode codepoint, when prefixed with `U+` or `0x`
- When searching by character or hex code point and the character does not exist in the font nor in the activated glyph sets, still append it to the search results, so users can conveniently access such characters
- More clearly visualize in the glyph search list if a glyph exists or not
- Fix searching for characters that are regex meta chars, like `*` or `^`