### PR TITLE
[fontra-workflow] Re-sort workflow test files to have the operational keyword first in the steps

### DIFF
--- a/test-py/data/workflow-sources/add-features.yaml
+++ b/test-py/data/workflow-sources/add-features.yaml
@@ -1,7 +1,7 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-merge-features-A.fontra
-  - featureFile: test-py/data/workflow/add-features.fea
-    filter: add-features
-  - destination: output-add-features.fontra
-    output: fontra-write
+  - filter: add-features
+    featureFile: test-py/data/workflow/add-features.fea
+  - output: fontra-write
+    destination: output-add-features.fontra

--- a/test-py/data/workflow-sources/adjust-axes-no-mapping-no-source-remap.yaml
+++ b/test-py/data/workflow-sources/adjust-axes-no-mapping-no-source-remap.yaml
@@ -8,12 +8,12 @@ steps:
     glyphNames:
       - A
   - filter: drop-axis-mappings
-  - axes:
+  - filter: adjust-axes
+    axes:
       weight:
         defaultValue: 400
         maxValue: 800
         minValue: 200
-    filter: adjust-axes
     remapSources: false
-  - destination: output-adjust-axes-no-mapping-no-source-remap.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-adjust-axes-no-mapping-no-source-remap.fontra

--- a/test-py/data/workflow-sources/adjust-axes-no-mapping.yaml
+++ b/test-py/data/workflow-sources/adjust-axes-no-mapping.yaml
@@ -8,11 +8,11 @@ steps:
     glyphNames:
       - A
   - filter: drop-axis-mappings
-  - axes:
+  - filter: adjust-axes
+    axes:
       weight:
         defaultValue: 400
         maxValue: 800
         minValue: 200
-    filter: adjust-axes
-  - destination: output-adjust-axes-no-mapping.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-adjust-axes-no-mapping.fontra

--- a/test-py/data/workflow-sources/adjust-axes-no-source-remap.yaml
+++ b/test-py/data/workflow-sources/adjust-axes-no-source-remap.yaml
@@ -7,12 +7,12 @@ steps:
   - filter: subset-glyphs
     glyphNames:
       - A
-  - axes:
+  - filter: adjust-axes
+    axes:
       weight:
         defaultValue: 400
         maxValue: 800
         minValue: 200
-    filter: adjust-axes
     remapSources: false
-  - destination: output-adjust-axes-no-source-remap.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-adjust-axes-no-source-remap.fontra

--- a/test-py/data/workflow-sources/adjust-axes-set-axis-values.yaml
+++ b/test-py/data/workflow-sources/adjust-axes-set-axis-values.yaml
@@ -3,7 +3,8 @@ steps:
     source: test-py/data/workflow/input1-A.fontra
   - filter: subset-glyphs
     glyphNames: []
-  - axes:
+  - filter: adjust-axes
+    axes:
       weight:
         hidden: true
         valueLabels:
@@ -12,6 +13,5 @@ steps:
             value: 400
           - name: Bold
             value: 700
-    filter: adjust-axes
-  - destination: output-adjust-axes-set-axis-values.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-adjust-axes-set-axis-values.fontra

--- a/test-py/data/workflow-sources/adjust-axes.yaml
+++ b/test-py/data/workflow-sources/adjust-axes.yaml
@@ -4,11 +4,11 @@ steps:
   - filter: subset-glyphs
     glyphNames:
       - A
-  - axes:
+  - filter: adjust-axes
+    axes:
       weight:
         defaultValue: 400
         maxValue: 800
         minValue: 200
-    filter: adjust-axes
-  - destination: output-adjust-axes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-adjust-axes.fontra

--- a/test-py/data/workflow-sources/amend-cmap-from-file.yaml
+++ b/test-py/data/workflow-sources/amend-cmap-from-file.yaml
@@ -2,11 +2,11 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
   - filter: drop-unused-sources-and-layers
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
-    filter: subset-axes
   - filter: drop-shapes
-  - cmapFile: test-py/data/workflow/amend-cmap-cmap.txt
-    filter: amend-cmap
-  - destination: output-amend-cmap.fontra
-    output: fontra-write
+  - filter: amend-cmap
+    cmapFile: test-py/data/workflow/amend-cmap-cmap.txt
+  - output: fontra-write
+    destination: output-amend-cmap.fontra

--- a/test-py/data/workflow-sources/amend-cmap.yaml
+++ b/test-py/data/workflow-sources/amend-cmap.yaml
@@ -2,16 +2,16 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
   - filter: drop-unused-sources-and-layers
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
-    filter: subset-axes
   - filter: drop-shapes
-  - cmap:
+  - filter: amend-cmap
+    cmap:
       U+0041: A
       66: null
       U+0061: null
       98: null
       4660: B
-    filter: amend-cmap
-  - destination: output-amend-cmap.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-amend-cmap.fontra

--- a/test-py/data/workflow-sources/axis-value-inheritance.yaml
+++ b/test-py/data/workflow-sources/axis-value-inheritance.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-axis-value-inheritance.fontra
   - filter: decompose-composites
-  - destination: output-axis-value-inheritance.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-axis-value-inheritance.fontra

--- a/test-py/data/workflow-sources/cache-tests.yaml
+++ b/test-py/data/workflow-sources/cache-tests.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input1-A.fontra
   - filter: memory-cache
   - filter: disk-cache
-  - destination: input1-A.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: input1-A.fontra

--- a/test-py/data/workflow-sources/check-interpolation-no-fail.yaml
+++ b/test-py/data/workflow-sources/check-interpolation-no-fail.yaml
@@ -3,8 +3,8 @@ steps:
     source: test-py/data/workflow/input-check-interpolation.fontra
   - filter: check-interpolation
     fixWithFallback: true
-  - destination: output-check-interpolation-no-fail.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-check-interpolation-no-fail.fontra
 test-info:
   continue-on-error: true
   expected-log:

--- a/test-py/data/workflow-sources/check-interpolation.yaml
+++ b/test-py/data/workflow-sources/check-interpolation.yaml
@@ -2,8 +2,8 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-check-interpolation.fontra
   - filter: check-interpolation
-  - destination: output-check-interpolation.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-check-interpolation.fontra
 test-info:
   continue-on-error: true
   expected-log:

--- a/test-py/data/workflow-sources/clear-location-base.yaml
+++ b/test-py/data/workflow-sources/clear-location-base.yaml
@@ -7,5 +7,5 @@ steps:
       - B
   - filter: drop-shapes
   - filter: clear-location-base
-  - destination: output-clear-location-base.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-clear-location-base.fontra

--- a/test-py/data/workflow-sources/convert-to-quadratics.yaml
+++ b/test-py/data/workflow-sources/convert-to-quadratics.yaml
@@ -4,5 +4,5 @@ steps:
   - filter: convert-to-quadratics
     maximumError: 1
     reverseDirection: false
-  - destination: output-convert-to-quadratics.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-convert-to-quadratics.fontra

--- a/test-py/data/workflow-sources/decompose-composites-location-base.yaml
+++ b/test-py/data/workflow-sources/decompose-composites-location-base.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/mutatorsans/MutatorSansLocationBase.fontra
   - filter: decompose-composites
-  - destination: output-decompose-composites-location-base.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-decompose-composites-location-base.fontra

--- a/test-py/data/workflow-sources/decompose-composites.yaml
+++ b/test-py/data/workflow-sources/decompose-composites.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-composites.fontra
   - filter: decompose-composites
-  - destination: output-decompose-composites.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-decompose-composites.fontra

--- a/test-py/data/workflow-sources/decompose-only-variable-composites.yaml
+++ b/test-py/data/workflow-sources/decompose-only-variable-composites.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input-composites.fontra
   - filter: decompose-composites
     onlyVariableComposites: true
-  - destination: output-decompose-only-variable-composites.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-decompose-only-variable-composites.fontra

--- a/test-py/data/workflow-sources/decompose-variable-composites-deep-axes.yaml
+++ b/test-py/data/workflow-sources/decompose-variable-composites-deep-axes.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input-variable-composites-deep-axes.fontra
   - filter: decompose-composites
     onlyVariableComposites: true
-  - destination: output-decompose-variable-composites-deep-axes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-decompose-variable-composites-deep-axes.fontra

--- a/test-py/data/workflow-sources/decompose-variable-composites.yaml
+++ b/test-py/data/workflow-sources/decompose-variable-composites.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input-variable-composites.fontra
   - filter: decompose-composites
     onlyVariableComposites: true
-  - destination: output-decompose-variable-composites.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-decompose-variable-composites.fontra

--- a/test-py/data/workflow-sources/drop-axis-mappings-with-explicit-axis.yaml
+++ b/test-py/data/workflow-sources/drop-axis-mappings-with-explicit-axis.yaml
@@ -4,8 +4,8 @@ steps:
   - filter: subset-glyphs
     glyphNames:
       - A
-  - axes:
+  - filter: drop-axis-mappings
+    axes:
       - non-existent
-    filter: drop-axis-mappings
-  - destination: output-drop-axis-mapping-noop.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-drop-axis-mapping-noop.fontra

--- a/test-py/data/workflow-sources/drop-axis-mappings.yaml
+++ b/test-py/data/workflow-sources/drop-axis-mappings.yaml
@@ -5,5 +5,5 @@ steps:
     glyphNames:
       - A
   - filter: drop-axis-mappings
-  - destination: output-drop-axis-mapping.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-drop-axis-mapping.fontra

--- a/test-py/data/workflow-sources/drop-cross-axis-mappings.yaml
+++ b/test-py/data/workflow-sources/drop-cross-axis-mappings.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-cross-axis-mappings.fontra
   - filter: drop-cross-axis-mappings
-  - destination: output-drop-cross-axis-mappings.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-drop-cross-axis-mappings.fontra

--- a/test-py/data/workflow-sources/drop-font-sources-and-kerning.yaml
+++ b/test-py/data/workflow-sources/drop-font-sources-and-kerning.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input1-A.fontra
   - filter: drop-shapes
   - filter: drop-font-sources-and-kerning
-  - destination: output-drop-font-sources-and-kerning.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-drop-font-sources-and-kerning.fontra

--- a/test-py/data/workflow-sources/drop-unreachable-glyphs-composed.yaml
+++ b/test-py/data/workflow-sources/drop-unreachable-glyphs-composed.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-drop-unreachable-glyphs.fontra
   - filter: drop-unreachable-glyphs
-  - destination: output-drop-unreachable-glyphs-composed.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-drop-unreachable-glyphs-composed.fontra

--- a/test-py/data/workflow-sources/drop-unreachable-glyphs-decomposed.yaml
+++ b/test-py/data/workflow-sources/drop-unreachable-glyphs-decomposed.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input-drop-unreachable-glyphs.fontra
   - filter: decompose-composites
   - filter: drop-unreachable-glyphs
-  - destination: output-drop-unreachable-glyphs-decomposed.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-drop-unreachable-glyphs-decomposed.fontra

--- a/test-py/data/workflow-sources/drop-unused-sources-and-layers.yaml
+++ b/test-py/data/workflow-sources/drop-unused-sources-and-layers.yaml
@@ -5,5 +5,5 @@ steps:
     glyphNames:
       - S
   - filter: drop-unused-sources-and-layers
-  - destination: output-drop-unused-sources-and-layers.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-drop-unused-sources-and-layers.fontra

--- a/test-py/data/workflow-sources/error-glyph.yaml
+++ b/test-py/data/workflow-sources/error-glyph.yaml
@@ -1,8 +1,8 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-error-glyph.fontra
-  - destination: output-error-glyph.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-error-glyph.fontra
 test-info:
   continue-on-error: true
   expected-log:

--- a/test-py/data/workflow-sources/fork-merge.yaml
+++ b/test-py/data/workflow-sources/fork-merge.yaml
@@ -1,8 +1,8 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
-  - axisNames: []
-    filter: subset-axes
+  - filter: subset-axes
+    axisNames: []
   - fork-merge: null
     steps:
       - filter: subset-glyphs
@@ -10,8 +10,8 @@ steps:
           - B
       - filter: scale
         scaleFactor: 0.5
-  - destination: output-fork-merge.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-fork-merge.fontra
 test-info:
   expected-log:
     - level: 30

--- a/test-py/data/workflow-sources/fork.yaml
+++ b/test-py/data/workflow-sources/fork.yaml
@@ -1,19 +1,19 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
-  - axisNames: []
-    filter: subset-axes
+  - filter: subset-axes
+    axisNames: []
   - fork: null
     steps:
       - filter: subset-glyphs
         glyphNames:
           - A
-      - destination: output-fork-A.fontra
-        output: fontra-write
+      - output: fontra-write
+        destination: output-fork-A.fontra
   - fork: null
     steps:
       - filter: subset-glyphs
         glyphNames:
           - B
-      - destination: output-fork-B.fontra
-        output: fontra-write
+      - output: fontra-write
+        destination: output-fork-B.fontra

--- a/test-py/data/workflow-sources/generate-kern-feature.yaml
+++ b/test-py/data/workflow-sources/generate-kern-feature.yaml
@@ -1,7 +1,7 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-merge-kerning-A.fontra
-  - dropKern: true
-    filter: generate-kern-feature
-  - destination: output-generate-kern-feature.fontra
-    output: fontra-write
+  - filter: generate-kern-feature
+    dropKern: true
+  - output: fontra-write
+    destination: output-generate-kern-feature.fontra

--- a/test-py/data/workflow-sources/generate-palt-vpal-feature-single-source.yaml
+++ b/test-py/data/workflow-sources/generate-palt-vpal-feature-single-source.yaml
@@ -1,8 +1,8 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-generate-palt-vpal-feature.fontra
-  - axisNames: []
-    filter: subset-axes
+  - filter: subset-axes
+    axisNames: []
   - filter: set-vertical-glyph-metrics
     verticalOrigin: 880
     yAdvance: 1000
@@ -10,5 +10,5 @@ steps:
     languageSystems:
       - - kana
         - dflt
-  - destination: output-generate-palt-vpal-feature-single-source.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-generate-palt-vpal-feature-single-source.fontra

--- a/test-py/data/workflow-sources/generate-palt-vpal-feature.yaml
+++ b/test-py/data/workflow-sources/generate-palt-vpal-feature.yaml
@@ -5,5 +5,5 @@ steps:
     verticalOrigin: 880
     yAdvance: 1000
   - filter: generate-palt-vpal-feature
-  - destination: output-generate-palt-vpal-feature.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-generate-palt-vpal-feature.fontra

--- a/test-py/data/workflow-sources/generate-vkrn-feature.yaml
+++ b/test-py/data/workflow-sources/generate-vkrn-feature.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-generate-vkrn-feature.fontra
   - filter: generate-vkrn-feature
-  - destination: output-generate-vkrn-feature.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-generate-vkrn-feature.fontra

--- a/test-py/data/workflow-sources/instantiate-full-cond-subst.yaml
+++ b/test-py/data/workflow-sources/instantiate-full-cond-subst.yaml
@@ -1,14 +1,14 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-cond-subst.fontra
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
       - width
-    filter: subset-axes
   - filter: instantiate
     location:
       weight: 300
       width: 400
   - filter: round-coordinates
-  - destination: output-instantiate-full-cond-subst.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-instantiate-full-cond-subst.fontra

--- a/test-py/data/workflow-sources/instantiate-full.yaml
+++ b/test-py/data/workflow-sources/instantiate-full.yaml
@@ -5,14 +5,14 @@ steps:
     glyphNames:
       - A
       - B
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
       - width
-    filter: subset-axes
   - filter: instantiate
     location:
       weight: 300
       width: 400
   - filter: round-coordinates
-  - destination: output-instantiate-full.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-instantiate-full.fontra

--- a/test-py/data/workflow-sources/instantiate-location-base.yaml
+++ b/test-py/data/workflow-sources/instantiate-location-base.yaml
@@ -9,5 +9,5 @@ steps:
     location:
       weight: 300
       width: 400
-  - destination: output-instantiate-location-base.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-instantiate-location-base.fontra

--- a/test-py/data/workflow-sources/instantiate-partial-cond-subst.yaml
+++ b/test-py/data/workflow-sources/instantiate-partial-cond-subst.yaml
@@ -1,13 +1,13 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-cond-subst.fontra
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
       - width
-    filter: subset-axes
   - filter: instantiate
     location:
       width: 200
   - filter: round-coordinates
-  - destination: output-instantiate-partial-cond-subst.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-instantiate-partial-cond-subst.fontra

--- a/test-py/data/workflow-sources/instantiate-partial.yaml
+++ b/test-py/data/workflow-sources/instantiate-partial.yaml
@@ -5,13 +5,13 @@ steps:
     glyphNames:
       - A
       - B
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
       - width
-    filter: subset-axes
   - filter: instantiate
     location:
       width: 400
   - filter: round-coordinates
-  - destination: output-instantiate-partial.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-instantiate-partial.fontra

--- a/test-py/data/workflow-sources/instantiate-with-cross-axis-mappings.yaml
+++ b/test-py/data/workflow-sources/instantiate-with-cross-axis-mappings.yaml
@@ -5,5 +5,5 @@ steps:
     applyCrossAxisMappings: true
     location:
       Diagonal: 40
-  - destination: output-instantiate-with-cross-axis-mappings.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-instantiate-with-cross-axis-mappings.fontra

--- a/test-py/data/workflow-sources/interpolation-fail.yaml
+++ b/test-py/data/workflow-sources/interpolation-fail.yaml
@@ -1,12 +1,12 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-interpolation-fail.fontra
-  - axes:
+  - filter: trim-axes
+    axes:
       weight:
         maxValue: 600
-    filter: trim-axes
-  - destination: output-interpolation-fail.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-interpolation-fail.fontra
 test-info:
   expected-log:
     - level: 40

--- a/test-py/data/workflow-sources/invalid-cubic-off-curve-points.yaml
+++ b/test-py/data/workflow-sources/invalid-cubic-off-curve-points.yaml
@@ -1,6 +1,5 @@
-# https://github.com/fontra/fontra/issues/2527
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-invalid-cubic-off-curve-points.fontra
-  - destination: output-invalid-cubic-off-curve-points.ufo
-    output: fontra-write
+  - output: fontra-write
+    destination: output-invalid-cubic-off-curve-points.ufo

--- a/test-py/data/workflow-sources/merge-axes.yaml
+++ b/test-py/data/workflow-sources/merge-axes.yaml
@@ -3,8 +3,8 @@ steps:
     source: test-py/data/workflow/input2-A.fontra
   - input: fontra-read
     source: test-py/data/workflow/input2-B.fontra
-  - destination: output-merge-axes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-merge-axes.fontra
 test-info:
   expected-log:
     - level: 40

--- a/test-py/data/workflow-sources/merge-codepoint-conflict.yaml
+++ b/test-py/data/workflow-sources/merge-codepoint-conflict.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input1-A.fontra
   - input: fontra-read
     source: test-py/data/workflow/input-merge-codepoint-conflict.fontra
-  - destination: output-merge-codepoint-conflict.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-merge-codepoint-conflict.fontra

--- a/test-py/data/workflow-sources/merge-features.yaml
+++ b/test-py/data/workflow-sources/merge-features.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input-merge-features-A.fontra
   - input: fontra-read
     source: test-py/data/workflow/input-merge-features-B.fontra
-  - destination: output-merge-features.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-merge-features.fontra

--- a/test-py/data/workflow-sources/merge-kerning.yaml
+++ b/test-py/data/workflow-sources/merge-kerning.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input-merge-kerning-A.fontra
   - input: fontra-read
     source: test-py/data/workflow/input-merge-kerning-B.fontra
-  - destination: output-merge-kerning.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-merge-kerning.fontra

--- a/test-py/data/workflow-sources/merge-plain.yaml
+++ b/test-py/data/workflow-sources/merge-plain.yaml
@@ -3,8 +3,8 @@ steps:
     source: test-py/data/workflow/input1-A.fontra
   - input: fontra-read
     source: test-py/data/workflow/input1-B.fontra
-  - destination: output-merge-plain.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-merge-plain.fontra
 test-info:
   expected-log:
     - level: 30

--- a/test-py/data/workflow-sources/move-default-location-base.yaml
+++ b/test-py/data/workflow-sources/move-default-location-base.yaml
@@ -9,5 +9,5 @@ steps:
     newDefaultUserLocation:
       weight: 300
       width: 400
-  - destination: output-move-default-location-base.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-move-default-location-base.fontra

--- a/test-py/data/workflow-sources/propagate-anchors.yaml
+++ b/test-py/data/workflow-sources/propagate-anchors.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-propagate-anchors.fontra
   - filter: propagate-anchors
-  - destination: output-propagate-anchors.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-propagate-anchors.fontra

--- a/test-py/data/workflow-sources/remove-overlaps.yaml
+++ b/test-py/data/workflow-sources/remove-overlaps.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
   - filter: remove-overlaps
-  - destination: output-remove-overlaps.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-remove-overlaps.fontra

--- a/test-py/data/workflow-sources/rename-axes.yaml
+++ b/test-py/data/workflow-sources/rename-axes.yaml
@@ -4,11 +4,11 @@ steps:
   - filter: subset-glyphs
     glyphNames:
       - A
-  - axes:
+  - filter: rename-axes
+    axes:
       weight:
         label: Thickness
         name: Thickness
         tag: THCK
-    filter: rename-axes
-  - destination: output-rename-axes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-rename-axes.fontra

--- a/test-py/data/workflow-sources/round-coordinates.yaml
+++ b/test-py/data/workflow-sources/round-coordinates.yaml
@@ -5,17 +5,17 @@ steps:
     glyphNames:
       - E
       - Aacute
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
-    filter: subset-axes
   - filter: move-default-location
     newDefaultUserLocation:
       weight: 431
-  - axes:
+  - filter: trim-axes
+    axes:
       weight:
         maxValue: 734
         minValue: 223
-    filter: trim-axes
   - filter: round-coordinates
-  - destination: output-round-coordinates.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-round-coordinates.fontra

--- a/test-py/data/workflow-sources/scale.yaml
+++ b/test-py/data/workflow-sources/scale.yaml
@@ -4,5 +4,5 @@ steps:
     steps:
       - filter: scale
         scaleFactor: 0.75
-  - destination: output-scale.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-scale.fontra

--- a/test-py/data/workflow-sources/set-font-info.yaml
+++ b/test-py/data/workflow-sources/set-font-info.yaml
@@ -6,8 +6,8 @@ steps:
       designer: Joe Font Designer
       familyName: A Brand New Font
       unknownName: Unknown, will be warned about
-  - destination: output-set-font-info.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-set-font-info.fontra
 test-info:
   expected-log:
     - level: 40

--- a/test-py/data/workflow-sources/set-location-base.yaml
+++ b/test-py/data/workflow-sources/set-location-base.yaml
@@ -9,5 +9,5 @@ steps:
   - filter: drop-shapes
   - filter: clear-location-base
   - filter: set-location-base
-  - destination: output-set-location-base.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-set-location-base.fontra

--- a/test-py/data/workflow-sources/set-vertical-glyph-metrics-from-anchors.yaml
+++ b/test-py/data/workflow-sources/set-vertical-glyph-metrics-from-anchors.yaml
@@ -5,5 +5,5 @@ steps:
     verticalOrigin: 880
     yAdvance: 1000
   - filter: set-vertical-glyph-metrics-from-anchors
-  - destination: output-set-vertical-glyph-metrics-from-anchors.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-set-vertical-glyph-metrics-from-anchors.fontra

--- a/test-py/data/workflow-sources/set-vertical-glyph-metrics.yaml
+++ b/test-py/data/workflow-sources/set-vertical-glyph-metrics.yaml
@@ -4,5 +4,5 @@ steps:
   - filter: set-vertical-glyph-metrics
     verticalOrigin: 880
     yAdvance: 1000
-  - destination: output-set-vertical-glyph-metrics.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-set-vertical-glyph-metrics.fontra

--- a/test-py/data/workflow-sources/shallow-decompose-composites-single-component.yaml
+++ b/test-py/data/workflow-sources/shallow-decompose-composites-single-component.yaml
@@ -1,8 +1,8 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-variable-composites.fontra
-  - componentGlyphNames:
+  - filter: shallow-decompose-composites
+    componentGlyphNames:
       - VG_4E28_00
-    filter: shallow-decompose-composites
-  - destination: output-shallow-decompose-composites-single-component.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-shallow-decompose-composites-single-component.fontra

--- a/test-py/data/workflow-sources/shallow-decompose-composites-single-glyph-component.yaml
+++ b/test-py/data/workflow-sources/shallow-decompose-composites-single-glyph-component.yaml
@@ -1,10 +1,10 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-variable-composites.fontra
-  - componentGlyphNames:
+  - filter: shallow-decompose-composites
+    componentGlyphNames:
       - VG_4E28_00
-    filter: shallow-decompose-composites
     glyphNames:
       - T_2FF0_80B2
-  - destination: output-shallow-decompose-composites-single-glyph-component.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-shallow-decompose-composites-single-glyph-component.fontra

--- a/test-py/data/workflow-sources/shallow-decompose-composites-single-glyph.yaml
+++ b/test-py/data/workflow-sources/shallow-decompose-composites-single-glyph.yaml
@@ -4,5 +4,5 @@ steps:
   - filter: shallow-decompose-composites
     glyphNames:
       - uni4FFC
-  - destination: output-shallow-decompose-composites-single-glyph.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-shallow-decompose-composites-single-glyph.fontra

--- a/test-py/data/workflow-sources/shallow-decompose-composites.yaml
+++ b/test-py/data/workflow-sources/shallow-decompose-composites.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-variable-composites.fontra
   - filter: shallow-decompose-composites
-  - destination: output-shallow-decompose-composites.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-shallow-decompose-composites.fontra

--- a/test-py/data/workflow-sources/subset-by-development-status-all-no.yaml
+++ b/test-py/data/workflow-sources/subset-by-development-status-all-no.yaml
@@ -7,5 +7,5 @@ steps:
     statuses:
       - 4
   - filter: drop-unreachable-glyphs
-  - destination: output-subset-by-development-status-no.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-by-development-status-no.fontra

--- a/test-py/data/workflow-sources/subset-by-development-status-any-no.yaml
+++ b/test-py/data/workflow-sources/subset-by-development-status-any-no.yaml
@@ -7,5 +7,5 @@ steps:
     statuses:
       - 2
   - filter: drop-unreachable-glyphs
-  - destination: output-subset-by-development-status-no.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-by-development-status-no.fontra

--- a/test-py/data/workflow-sources/subset-by-development-status-any-yes.yaml
+++ b/test-py/data/workflow-sources/subset-by-development-status-any-yes.yaml
@@ -7,5 +7,5 @@ steps:
     statuses:
       - 3
   - filter: drop-unreachable-glyphs
-  - destination: output-subset-by-development-status-yes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-by-development-status-yes.fontra

--- a/test-py/data/workflow-sources/subset-by-development-status-default-no.yaml
+++ b/test-py/data/workflow-sources/subset-by-development-status-default-no.yaml
@@ -6,5 +6,5 @@ steps:
     statuses:
       - 3
   - filter: drop-unreachable-glyphs
-  - destination: output-subset-by-development-status-no.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-by-development-status-no.fontra

--- a/test-py/data/workflow-sources/subset-by-development-status-default-yes.yaml
+++ b/test-py/data/workflow-sources/subset-by-development-status-default-yes.yaml
@@ -6,5 +6,5 @@ steps:
     statuses:
       - 4
   - filter: drop-unreachable-glyphs
-  - destination: output-subset-by-development-status-yes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-by-development-status-yes.fontra

--- a/test-py/data/workflow-sources/subset-cond-subst-closure.yaml
+++ b/test-py/data/workflow-sources/subset-cond-subst-closure.yaml
@@ -2,10 +2,10 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-cond-subst.fontra
   - filter: subset-glyphs
-    layoutHandling: closure
     glyphNames:
       - A
       - I
       - S
-  - destination: output-cond-subst.fontra
-    output: fontra-write
+    layoutHandling: closure
+  - output: fontra-write
+    destination: output-cond-subst.fontra

--- a/test-py/data/workflow-sources/subset-drop-axis.yaml
+++ b/test-py/data/workflow-sources/subset-drop-axis.yaml
@@ -2,9 +2,9 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
   - filter: drop-unused-sources-and-layers
-  - dropAxisNames:
+  - filter: subset-axes
+    dropAxisNames:
       - width
       - italic
-    filter: subset-axes
-  - destination: output-subset-axes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-axes.fontra

--- a/test-py/data/workflow-sources/subset-drop-glyphs.yaml
+++ b/test-py/data/workflow-sources/subset-drop-glyphs.yaml
@@ -1,7 +1,7 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
-  - dropGlyphNamesFile: test-py/data/workflow/subset-drop-glyph-names.txt
-    filter: subset-glyphs
-  - destination: output-subset-keep-drop-glyphs.fontra
-    output: fontra-write
+  - filter: subset-glyphs
+    dropGlyphNamesFile: test-py/data/workflow/subset-drop-glyph-names.txt
+  - output: fontra-write
+    destination: output-subset-keep-drop-glyphs.fontra

--- a/test-py/data/workflow-sources/subset-features-closure.yaml
+++ b/test-py/data/workflow-sources/subset-features-closure.yaml
@@ -5,8 +5,8 @@ steps:
     glyphNames:
       - A
     layoutHandling: closure
-  - destination: output-subset-features.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-features.fontra
 test-info:
   expected-log:
     - level: 30

--- a/test-py/data/workflow-sources/subset-features.yaml
+++ b/test-py/data/workflow-sources/subset-features.yaml
@@ -5,8 +5,8 @@ steps:
     glyphNames:
       - A
       - A.alt
-  - destination: output-subset-features.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-features.fontra
 test-info:
   expected-log:
     - level: 30

--- a/test-py/data/workflow-sources/subset-glyphs-kerning.yaml
+++ b/test-py/data/workflow-sources/subset-glyphs-kerning.yaml
@@ -8,5 +8,5 @@ steps:
       - O
       - T
       - V
-  - destination: output-subset-glyphs-kerning.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-glyphs-kerning.fontra

--- a/test-py/data/workflow-sources/subset-keep-axis-location-base.yaml
+++ b/test-py/data/workflow-sources/subset-keep-axis-location-base.yaml
@@ -6,8 +6,8 @@ steps:
     glyphNames:
       - B
   - filter: drop-shapes
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
-    filter: subset-axes
-  - destination: output-subset-axes-location-base.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-axes-location-base.fontra

--- a/test-py/data/workflow-sources/subset-keep-axis.yaml
+++ b/test-py/data/workflow-sources/subset-keep-axis.yaml
@@ -2,8 +2,8 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input1-A.fontra
   - filter: drop-unused-sources-and-layers
-  - axisNames:
+  - filter: subset-axes
+    axisNames:
       - weight
-    filter: subset-axes
-  - destination: output-subset-axes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-axes.fontra

--- a/test-py/data/workflow-sources/subset-keep-glyphs.yaml
+++ b/test-py/data/workflow-sources/subset-keep-glyphs.yaml
@@ -3,5 +3,5 @@ steps:
     source: test-py/data/workflow/input1-A.fontra
   - filter: subset-glyphs
     glyphNamesFile: test-py/data/workflow/subset-keep-glyph-names.txt
-  - destination: output-subset-keep-drop-glyphs.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-keep-drop-glyphs.fontra

--- a/test-py/data/workflow-sources/subset-move-default-location-no-sources.yaml
+++ b/test-py/data/workflow-sources/subset-move-default-location-no-sources.yaml
@@ -3,12 +3,12 @@ steps:
     source: test-py/data/workflow/input-move-default-location.fontra
   - filter: drop-font-sources-and-kerning
   - filter: drop-shapes
-  - dropAxisNames:
+  - filter: subset-axes
+    dropAxisNames:
       - italic
-    filter: subset-axes
   - filter: move-default-location
     newDefaultUserLocation:
       weight: 300
       width: 400
-  - destination: output-move-default-location-no-sources.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-move-default-location-no-sources.fontra

--- a/test-py/data/workflow-sources/subset-move-default-location.yaml
+++ b/test-py/data/workflow-sources/subset-move-default-location.yaml
@@ -1,12 +1,12 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-move-default-location.fontra
-  - dropAxisNames:
+  - filter: subset-axes
+    dropAxisNames:
       - italic
-    filter: subset-axes
   - filter: move-default-location
     newDefaultUserLocation:
       weight: 300
       width: 400
-  - destination: output-move-default-location.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-move-default-location.fontra

--- a/test-py/data/workflow-sources/subset-scale-kerning.yaml
+++ b/test-py/data/workflow-sources/subset-scale-kerning.yaml
@@ -12,5 +12,5 @@ steps:
           - T
           - V
       - filter: round-coordinates
-  - destination: output-subset-scale-kerning.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-scale-kerning.fontra

--- a/test-py/data/workflow-sources/subset-scale.yaml
+++ b/test-py/data/workflow-sources/subset-scale.yaml
@@ -18,5 +18,5 @@ steps:
           - C
           - D
       - filter: drop-background-images
-  - destination: output-subset-scale.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-subset-scale.fontra

--- a/test-py/data/workflow-sources/trim-axes-location-base.yaml
+++ b/test-py/data/workflow-sources/trim-axes-location-base.yaml
@@ -5,13 +5,13 @@ steps:
     glyphNames:
       - A
       - B
-  - axes:
+  - filter: trim-axes
+    axes:
       weight:
         maxValue: 300
         minValue: 100
       width:
         maxValue: 400
         minValue: 0
-    filter: trim-axes
-  - destination: output-trim-axes-location-base.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-trim-axes-location-base.fontra

--- a/test-py/data/workflow-sources/trim-axes.yaml
+++ b/test-py/data/workflow-sources/trim-axes.yaml
@@ -1,13 +1,13 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-trim-axes.fontra
-  - axes:
+  - filter: trim-axes
+    axes:
       weight:
         maxValue: 800
         minValue: 200
       width:
         maxValue: 700
         minValue: 100
-    filter: trim-axes
-  - destination: output-trim-axes.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-trim-axes.fontra

--- a/test-py/data/workflow-sources/trim-variable-glyphs-1.yaml
+++ b/test-py/data/workflow-sources/trim-variable-glyphs-1.yaml
@@ -2,5 +2,5 @@ steps:
   - input: fontra-read
     source: test-py/data/workflow/input-variable-composites.fontra
   - filter: trim-variable-glyphs
-  - destination: output-trim-variable-glyphs-1.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-trim-variable-glyphs-1.fontra

--- a/test-py/data/workflow-sources/trim-variable-glyphs-2.yaml
+++ b/test-py/data/workflow-sources/trim-variable-glyphs-2.yaml
@@ -1,11 +1,11 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-variable-composites.fontra
-  - axes:
+  - filter: trim-axes
+    axes:
       wght:
         maxValue: 500
         minValue: 200
-    filter: trim-axes
   - filter: trim-variable-glyphs
-  - destination: output-trim-variable-glyphs-2.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-trim-variable-glyphs-2.fontra

--- a/test-py/data/workflow-sources/trim-variable-glyphs-3.yaml
+++ b/test-py/data/workflow-sources/trim-variable-glyphs-3.yaml
@@ -4,11 +4,11 @@ steps:
   - filter: move-default-location
     newDefaultUserLocation:
       wght: 500
-  - axes:
+  - filter: trim-axes
+    axes:
       wght:
         maxValue: 900
         minValue: 500
-    filter: trim-axes
   - filter: trim-variable-glyphs
-  - destination: output-trim-variable-glyphs-3.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-trim-variable-glyphs-3.fontra

--- a/test-py/data/workflow-sources/upconvert-legacy-kerning.yaml
+++ b/test-py/data/workflow-sources/upconvert-legacy-kerning.yaml
@@ -1,5 +1,5 @@
 steps:
   - input: fontra-read
     source: test-py/data/workflow/input-upconvert-legacy-kerning.fontra
-  - destination: output-upconvert-legacy-kerning.fontra
-    output: fontra-write
+  - output: fontra-write
+    destination: output-upconvert-legacy-kerning.fontra


### PR DESCRIPTION
They key order (which functionally does not matter) got mangled when I created the individual test files from inline yaml data. This reads much better.