### PR TITLE
[fontra-workflow] If we're doing a full instantiate, avoid badly scaling algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Fontra
 
+## 2026-06-08 [version 2026.6.1]
+
+### Improvements
+
+- [fontra-workflow] Improve performance of full instantiation, especially when there are many axes. [PR 2621](https://github.com/fontra/fontra/pull/2621)
+
 ## 2026-06-07 [version 2026.6.0]
 
 ### Improvements

--- a/src/fontra/workflow/actions/axes.py
+++ b/src/fontra/workflow/actions/axes.py
@@ -480,6 +480,7 @@ class BaseMoveDefaultLocation(BaseFilter):
             originalDefaultSourceLocation,
             newDefaultSourceLocation,
             allAxisNames,
+            self._allowFullInstantiateShortcut(),
         )
 
         remainingAxisNames = {axis.name for axis in (await self.processedAxes).axes} | {
@@ -510,7 +511,9 @@ class BaseMoveDefaultLocation(BaseFilter):
             originalDefaultSourceLocation,
             newDefaultSourceLocation,
             self.fontInstancer.fontAxisNames,
+            self._allowFullInstantiateShortcut(),
         )
+
         newLocations = self._filterNewLocations(
             newLocations, await self.newDefaultSourceLocation
         )
@@ -542,6 +545,9 @@ class BaseMoveDefaultLocation(BaseFilter):
     def _shouldApplyCrossAxisMappings(self):
         return False
 
+    def _allowFullInstantiateShortcut(self):
+        return False
+
     def _filterAxisList(self, axes):
         raise NotImplementedError()
 
@@ -557,7 +563,13 @@ def moveDefaultLocations(
     originalDefaultSourceLocation,
     newDefaultSourceLocation,
     allAxisNames,
+    allowFullInstantiateShortcut=False,
 ):
+    if allowFullInstantiateShortcut and set(originalDefaultSourceLocation) <= set(
+        newDefaultSourceLocation
+    ):
+        return [newDefaultSourceLocation]
+
     movingAxisNames = set(newDefaultSourceLocation)
     interactingAxisNames = set()
 
@@ -644,6 +656,9 @@ class Instantiate(BaseMoveDefaultLocation):
 
     def _shouldApplyCrossAxisMappings(self):
         return self.applyCrossAxisMappings
+
+    def _allowFullInstantiateShortcut(self):
+        return True
 
     def _getDefaultUserLocation(self):
         return self.location


### PR DESCRIPTION
If we're doing a full instantiate (rather than slicing, or moving the default), bypass the moveDefaultLocations algorithm, which can perform very poorly when there are many axes.