### PR TITLE
Fix cross-axis mapper in the presence of discrete axes

### DIFF
--- a/src-js/fontra-core/src/cross-axis-mapper.js
+++ b/src-js/fontra-core/src/cross-axis-mapper.js
@@ -11,7 +11,10 @@ import {
 
 export class CrossAxisMapper {
   constructor(fontAxesSourceSpace, mappings) {
-    this.fontAxesSourceSpace = fontAxesSourceSpace;
+    // Ignore discrete axes for now
+    this.fontAxesSourceSpace = fontAxesSourceSpace.filter(
+      (axis) => axis.minValue !== undefined
+    );
     this.mappings = mappings;
     if (mappings?.length) {
       this._setupModel();

--- a/src-js/fontra-core/tests/test-cross-axis-mapper.js
+++ b/src-js/fontra-core/tests/test-cross-axis-mapper.js
@@ -3,7 +3,12 @@ import { expect } from "chai";
 import { parametrize } from "./test-support.js";
 
 describe("CrossAxisMapping Tests", () => {
-  const axes = [newAxis("Diagonal"), newAxis("Horizontal"), newAxis("Vertical")];
+  const axes = [
+    newAxis("Diagonal"),
+    newAxis("Horizontal"),
+    newAxis("Vertical"),
+    { name: "DiscreteAxis", values: [0, 1], defaultValue: 0 },
+  ];
 
   const mappings = [
     {

--- a/test-py/test_crossaxismapper.py
+++ b/test-py/test_crossaxismapper.py
@@ -1,6 +1,6 @@
 import pytest
 
-from fontra.core.classes import Axes, CrossAxisMapping, FontAxis
+from fontra.core.classes import Axes, CrossAxisMapping, DiscreteFontAxis, FontAxis
 from fontra.core.crossaxismapper import CrossAxisMapper
 
 
@@ -15,6 +15,14 @@ axes = Axes(
         newTestAxis("Diagonal"),
         newTestAxis("Horizontal"),
         newTestAxis("Vertical"),
+        # Add a discrete axis to test we don't crash in their presence
+        DiscreteFontAxis(
+            name="DiscreteAxis",
+            label="DiscreteAxis",
+            tag="Disc",
+            values=[0, 1],
+            defaultValue=0,
+        ),
     ],
     mappings=[
         CrossAxisMapping(


### PR DESCRIPTION
This fixes #2623 