### PR TITLE
[cross-axis mappings panel] Filter out discrete axes

### DIFF
--- a/src-js/views-fontinfo/src/panel-cross-axis-mapping.js
+++ b/src-js/views-fontinfo/src/panel-cross-axis-mapping.js
@@ -38,9 +38,10 @@ export class CrossAxisMappingPanel extends BaseInfoPanel {
   async setupUI(scrollToLastItem = false) {
     const mappings = this.fontController.axes.mappings;
 
+    // Map to source space and filter out discrete axes
     this.fontAxesSourceSpace = mapAxesFromUserSpaceToSourceSpace(
       this.fontController.axes.axes
-    );
+    ).filter((axis) => axis.minValue !== undefined);
 
     const container = html.div({
       style: "display: grid; gap: 0.5em;",


### PR DESCRIPTION
Discrete axes cannot play a role in cross-axis mappings, so we'll ignore them for now: don't show them in the UI. Followup to #2624