### PR TITLE
[filewatcher] Rework external change filtering, to improve behavior with OneDrive and iCloud

### DIFF
--- a/src/fontra/backends/filewatcher.py
+++ b/src/fontra/backends/filewatcher.py
@@ -1,8 +1,7 @@
 import asyncio
-import hashlib
 import logging
 import os
-from collections import defaultdict
+from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Iterable
 
@@ -17,10 +16,11 @@ class FileWatcher:
     paths: set[str] = field(init=False, default_factory=set)
     _stopEvent: asyncio.Event = field(init=False, default=asyncio.Event())
     _task: asyncio.Task | None = field(init=False, default=None)
-    _ignorePaths: dict[str, set[float | None]] = field(
-        init=False, default_factory=lambda: defaultdict(set)
+    # We keep a deque of a small amount of modification times per file, just in
+    # case we receive a changed event for a change after we've made another change
+    _ignorePaths: dict[str, deque[float | None]] = field(
+        init=False, default_factory=lambda: defaultdict(lambda: deque(maxlen=4))
     )
-    _ignorePathHashes: dict[str, bytes | None] = field(init=False, default_factory=dict)
 
     async def aclose(self) -> None:
         if self._task is None:
@@ -45,9 +45,7 @@ class FileWatcher:
 
     def ignoreNextChange(self, path: os.PathLike | str):
         path = os.fspath(path)
-        mtime = os.stat(path).st_mtime if os.path.exists(path) else None
-        self._ignorePaths[path].add(mtime)
-        self._ignorePathHashes[path] = fileContentHash(path)
+        self._ignorePaths[path].appendleft(getModificationTime(path))
 
     def _startWatching(self) -> None:
         # Stop the current loop after a delay, so that it can process pending changes.
@@ -75,17 +73,11 @@ class FileWatcher:
             # Can we ignore this changes based on a recorded modification time?
             mtimes = self._ignorePaths.get(path)
             if mtimes is not None:
-                mtime = os.stat(path).st_mtime if os.path.exists(path) else None
+                mtime = getModificationTime(path)
                 if mtime in mtimes:
-                    mtimes.remove(mtime)
-                    if not mtimes:
-                        del self._ignorePaths[path]
                     continue
-
-            # We still want to ignore the change if the contents didn't really change.
-            contentHash = self._ignorePathHashes.pop(path, None)
-            if contentHash is not None and contentHash == fileContentHash(path):
-                continue
+                # We have a true external change
+                del self._ignorePaths[path]
 
             filteredChanges.add((change, path))
 
@@ -116,9 +108,5 @@ async def setEventAfterDelay(event, delay=0.1) -> None:
     event.set()
 
 
-def fileContentHash(path: str) -> bytes | None:
-    if not os.path.isfile(path):
-        return None
-
-    with open(path, "rb") as f:
-        return hashlib.sha256(f.read()).digest()
+def getModificationTime(path) -> float | None:
+    return os.stat(path).st_mtime if os.path.exists(path) else None

--- a/test-py/test_filewatcher.py
+++ b/test-py/test_filewatcher.py
@@ -1,5 +1,7 @@
 import asyncio
+import os
 import pathlib
+import shutil
 from contextlib import aclosing
 
 from watchfiles import Change
@@ -65,12 +67,14 @@ async def test_filewatcher_basic(tmpdir):
     ) == sorted(collectedChanges)
 
 
-async def test_filewatcher_ignoreNextChange(tmpdir):
-    testDir = pathlib.Path(tmpdir) / "folder_to_watch"
+async def test_filewatcher_ignoreNextChange(tmp_path):
+    testDir = tmp_path / "folder_to_watch"
     testDir.mkdir()
 
     testPath = testDir / "testing.txt"
     testPath.write_text("testing")
+
+    testSwapPath = tmp_path / "testing_swap.txt"
 
     collectedChanges = []
 
@@ -95,24 +99,18 @@ async def test_filewatcher_ignoreNextChange(tmpdir):
         await asyncio.sleep(delay)
 
         testPath.write_text("hello2")
-        # this should cause the next event (caused byt the *previous* write)
+        # this should cause the next event (caused by the *previous* write)
         # to be ignored
         watcher.ignoreNextChange(testPath)
         await asyncio.sleep(delay)
 
-        # We also want subsequent writes that don't change the contents to
-        # be ignored
-        watcher.ignoreNextChange(testPath)
-        testPath.write_text("hello2")  # same contents
-        await asyncio.sleep(delay)
+        # Cause a file changed event, but with the same mtime, to emulate
+        # OneDrive and iCloud shared folder behavior
+        shutil.copy2(testPath, testSwapPath)  # keeps mtime
+        os.replace(testSwapPath, testPath)  # also keeps mtime
 
-        # But if a subsequent write writes *different* content, we do want
-        # to receive an event
-        watcher.ignoreNextChange(testPath)
-        testPath.write_text("hello3")
         await asyncio.sleep(delay)
 
     assert [
         ("folder_to_watch/testing.txt", "hello"),
-        ("folder_to_watch/testing.txt", "hello3"),
     ] == collectedChanges


### PR DESCRIPTION
Checking by content turns out not to be needed, so rip that out.

At least OneDrive and iCloud folders can cause *multiple* change events to be produced for a single file write: we need to hang on to the stored modification time, so we can ignore the second change event, too.

Reverts most of #2511, and fixes #2626.