### PR TITLE
[editor, pointer tool] Listen to tab/shift-tab to advance the selection

### DIFF
--- a/src-js/views-editor/src/edit-tools-pointer.js
+++ b/src-js/views-editor/src/edit-tools-pointer.js
@@ -25,6 +25,7 @@ import {
   boolInt,
   commandKeyProperty,
   enumerate,
+  modulo,
   parseSelection,
   range,
 } from "@fontra/core/utils.ts";
@@ -709,6 +710,62 @@ export class PointerTool extends BaseTool {
 
   get scalingEditBehavior() {
     return false;
+  }
+
+  handleKeyDown(event) {
+    if (event.key !== "Tab" || !this.sceneSettings.selectedGlyph?.isEditing) {
+      return;
+    }
+
+    const glyph = this.sceneModel.getSelectedPositionedGlyph()?.glyph;
+    if (!glyph) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const selectionTypes = ["point", "component", "anchor", "guideline"];
+
+    const parsedSelection = parseSelection(this.sceneSettings.selection);
+
+    const numItems = {
+      point: glyph.path.numPoints,
+      component: glyph.components.length,
+      anchor: glyph.anchors.length,
+      guideline: glyph.guidelines.length,
+    };
+
+    const selectionType =
+      selectionTypes.find((tp) => parsedSelection[tp]) ??
+      selectionTypes.find((tp) => numItems[tp]);
+
+    if (!selectionType) {
+      return;
+    }
+
+    const currentSelection = parsedSelection[selectionType];
+    const currentIndex = currentSelection?.at(event.shiftKey ? 0 : -1);
+    const numSelectionItems = numItems[selectionType];
+    const delta = event.shiftKey ? -1 : 1;
+
+    const newIndex = currentSelection
+      ? event.altKey && selectionType == "point"
+        ? // if we are selecting points, and the alt key is pressed,
+          // go to the next or previous contour
+          glyph.path.getAbsolutePointIndex(
+            modulo(
+              glyph.path.getContourIndex(currentIndex) + delta,
+              glyph.path.numContours
+            ),
+            event.shiftKey ? -1 : 0
+          )
+        : modulo(currentIndex + delta, numSelectionItems)
+      : event.shiftKey
+        ? numSelectionItems - 1
+        : 0;
+
+    this.sceneSettings.selection = new Set([`${selectionType}/${newIndex}`]);
   }
 
   activate() {


### PR DESCRIPTION
Make typing tab select the next item, and shift-tab select the previous item. If nothing is yet selected, select the first selectable item. If we are selecting points, make alt-tab go to the next *contour*, and alt-shift-tab to to the previous contour.

Cycling through will stick to the selected item type: once we're selecting a point, we'll cycle though the points. Same for components, anchors and guidelines. For example, if a component is selected, tab will cycle through the components.

This resolves #2638.