### PR TITLE
Keep forward browser history when going back

### DIFF
--- a/src-js/fontra-core/src/observable-object.ts
+++ b/src-js/fontra-core/src/observable-object.ts
@@ -7,6 +7,7 @@ export type Event<T, K extends keyof T> = {
   newValue: T[K];
   oldValue: T[K];
   senderInfo: any;
+  senderInfoStack: any[];
 };
 
 export type Listener<T> = (event: Event<T, keyof T>) => void;
@@ -149,10 +150,20 @@ export class ObservableController<T extends {}> {
     senderInfo?: any
   ) {
     // Schedule the calls in the event loop rather than call immediately
-    if (!senderInfo && this._senderInfoStack.length) {
+    const senderInfoStack = Array.from(this._senderInfoStack);
+    if (!senderInfo && senderInfoStack.length) {
       senderInfo = this._senderInfoStack.at(-1);
+    } else if (senderInfo) {
+      senderInfoStack.push(senderInfo);
     }
-    const event: Event<T, K> = { key, newValue, oldValue, senderInfo };
+
+    const event: Event<T, K> = {
+      key,
+      newValue,
+      oldValue,
+      senderInfo,
+      senderInfoStack,
+    };
     for (const item of chain(this._generalListeners, this._keyListeners[key] || [])) {
       if (item.immediate) {
         item.listener(event);

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -162,7 +162,10 @@ export class EditorController extends ViewController {
     this.sceneSettingsController.addKeyListener(
       [...persistentSceneSettingsKeys, "glyphLocation"],
       (event) => {
-        if (event.senderInfo?.senderID !== this && !event.senderInfo?.adjustViewBox) {
+        if (
+          !event.senderInfoStack.find((senderInfo) => senderInfo.senderID === this) &&
+          !event.senderInfo?.adjustViewBox
+        ) {
           this.updateWindowLocation(); // scheduled with delay
         }
       }


### PR DESCRIPTION
Browser forward history was sometimes lost when using the browser back button. This PR tries harder to not push unneeded history state.