### PR TITLE
js: switch from History API to Location API

### DIFF
--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -624,6 +624,16 @@ export function readObjectFromURLFragment() {
   return url.hash ? loadURLFragment(url.hash) : {};
 }
 
+let _writingURLFragment = false;
+/**
+ * Returns true in an event listener for `popstate` or `navigate` if the event
+ * was triggered by a call to `writeObjectToURLFragment`, and not by the user
+ * using the browser's navigation (forward and back buttons).
+ */
+export function eventIsCausedByWritingURLFragment() {
+  return _writingURLFragment;
+}
+
 export function writeObjectToURLFragment(obj: any, replace = false) {
   const newFragment = dumpURLFragment(obj);
   // @ts-ignore Typescript complains that window.location is missing some
@@ -633,10 +643,23 @@ export function writeObjectToURLFragment(obj: any, replace = false) {
     return;
   }
   url.hash = newFragment;
+
+  // See explanation on `eventIsCausedByWritingURLFragment`.
+  _writingURLFragment = true;
+  // We reset the value in a freshly queued `hashchange` listener which is
+  // guaranteed to fire after any other existing listener since it's new.
+  window.addEventListener(
+    "hashchange",
+    () => {
+      _writingURLFragment = false;
+    },
+    { once: true }
+  );
+
   if (replace) {
-    window.history.replaceState({}, "", url);
+    window.location.replace(url);
   } else {
-    window.history.pushState({}, "", url);
+    window.location.assign(url);
   }
 }
 

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -37,6 +37,7 @@ import { labeledCheckbox, labeledTextInput, pickFile } from "@fontra/core/ui-uti
 import {
   commandKeyProperty,
   enumerate,
+  eventIsCausedByWritingURLFragment,
   fetchJSON,
   hyphenatedToCamelCase,
   hyphenatedToLabel,
@@ -275,8 +276,27 @@ export class EditorController extends ViewController {
       200
     );
 
+    // The "popstate" event fires when the active history entry changes.
+    //
+    // We need to listen for this event so we can load the view state from
+    // the URL fragment, since the document does not reload if all that is
+    // different between the previous URL and the new one is the fragment.
     window.addEventListener("popstate", (event) => {
-      this.setupFromWindowLocation();
+      // When we write the URL fragment from our own code, with a call to our
+      // `writeObjectToURLFragment` function, this will also trigger the event.
+      //
+      // I'm not entirely sure that is what should happen based on the
+      // spec, but all 3 major browsers do it, so maybe it is correct.
+      //
+      // Regardless, we need to differentiate between a `popstate` caused by
+      // the user navigating with the forward/back buttons in their browser
+      // and one caused by us writing the URL fragment.
+      //
+      // We only need to run the setup function when it *wasn't* us who changed
+      // the URL (since if we did then we should already be in the right state).
+      if (!eventIsCausedByWritingURLFragment()) {
+        this.setupFromWindowLocation();
+      }
     });
 
     this.updateWithDelay();

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -28,6 +28,7 @@ import {
   asyncMap,
   consolidateCalls,
   dumpURLFragment,
+  eventIsCausedByWritingURLFragment,
   glyphMapToItemList,
   isActiveElementTypeable,
   modulo,
@@ -146,7 +147,9 @@ export class FontOverviewController extends ViewController {
     window.name = `fontra.fontoverview.${this.projectIdentifier}`;
 
     window.addEventListener("popstate", (event) => {
-      this._updateFromWindowLocation();
+      if (!eventIsCausedByWritingURLFragment()) {
+        this._updateFromWindowLocation();
+      }
     });
 
     this.fontOverviewSettingsController = new ObservableController({


### PR DESCRIPTION
Fixes #2654.

## Summary of Changes
This PR replaces the use of `window.history.replaceState` and `window.history.pushState` with the very similar `window.location.replace` and `window.location.assign`. The key difference between these two APIs is that the `history` methods allow associating an arbitrary object with each history entry, while the `location` methods do not; but we were passing an empty object for that anyway so that doesn't matter.

The motivation for this change is rather subtle, and I explain in more detail below, but ultimately it seems to have resolved a problem of hitching, lag, and freezing that occurred in long-running editing sessions in Safari.

However, another difference in behavior is that, while the `history` methods don't trigger the `popstate` event, the `location` methods *do*. We rely on the `popstate` event to restore view parameters as the user navigates their history with the browser's forward/back buttons or other UI. We don't want to run that logic, however, if we are the ones responsible for the URL hash (AKA fragment) changing, since it's at best redundant and at worst would cause all sorts of weird behaviors. In order to fix this, I added a flag that is set before changing the location in the `writeObjectToURLFragment` function and is cleared after any event listeners have fired. We gate our response to the `popstate` event on that flag to avoid any problems.

## Explanation
This was a painful problem to diagnose, but I'm *fairly* confident I diagnosed it correctly, since the fix (which was mercifully simple) did seem to resolve the lag and hitching I had experienced before.

Ultimately, the problem lies in Safari's "reader mode". It runs a script on the page to identify which, if any, elements represent the "article" content on the page. It does this when a page is first loaded, and, critically, in response to the `Navigation` API's `navigate` event ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event)).

This means that every time the URL changes, it tries to forget everything it knew about the page and then re-run its search logic. This would be fine, if slightly wasteful, but shouldn't create increasing amounts of lag. However, I believe what happens is that the external component that injects this script is injecting another copy of the script (which runs in its own execution context, it would seem, likely to try to prevent prototype pollution). This happens *every single time* that `replaceState` is called, which is up to 5 times a second. And every time a `navigate` event happens, every copy will `delete` its index of the elements on the page and make a new one... and all of those are cleaned up in the same garbage collection pass as the page's main thread uses. This means we end up with monstrous GCs that take hundreds of milliseconds, sometimes even thousands.

Now, the `navigate` event is triggered by every sort of navigation, including the `location` methods, but looking at the exact logic (thanks to the code that someone helpfully extracted from Safari), you can see that the scripts gates its response on the event's `hashChange` property:

https://github.com/NohamR/safari-internal-js/blob/8dc9429f8414533792e2fe34d1762a47369c852e/26.2/js/reader/ReaderArticleFinder.js#L5085-L5092

Despite only changing the hash, our call to `replaceState` (or `pushState`) does not result in an event with that property, which is by design, since it also - per spec - doesn't trigger the `hashchange` event. By using the `location` methods instead, the `hashChange` property will be set correctly on the `navigate` event, and the problem goes away.

I haven't checked if the change to the `location` methods also prevents the reader mode script from being duplicated in the first place, but I wouldn't be surprised if it does. Even if it doesn't, it prevents massive garbage collections and the editor will be as smooth after 6 hours of work as it is after 5 minutes, which was not the case before.

For completeness sake- I noted the existence of this problem (and tested the fix) in Safari version 26.5.

---

Ultimately, this shouldn't have been Fontra's problem to solve, it's a failure on the part of Safari, and quite a nasty bug at that. One can only hope that Apple will get their act together and fix it up at some point in the future.

> [!NOTE]
> You may want to test these changes in all the browsers just to make sure all the behavior seems correct to you. I did tests on my end, but you never know.