### PR TITLE
Fix URL updating for some situations

### DIFF
--- a/src-js/fontra-core/src/observable-object.ts
+++ b/src-js/fontra-core/src/observable-object.ts
@@ -109,13 +109,22 @@ export class ObservableController<T extends {}> {
 
   waitForKeyChange<K extends keyof T>(
     keyOrKeys: K | K[],
-    immediate = false
-  ): Promise<Event<T, keyof T>> {
+    immediate = false,
+    timeout?: number
+  ): Promise<Event<T, keyof T> | null> {
     return new Promise((resolve) => {
       const tempListener: Listener<T> = (event) => {
         this.removeKeyListener(keyOrKeys, tempListener);
+        clearTimeout(timerID);
         resolve(event);
       };
+
+      const timerID = timeout
+        ? setTimeout(() => {
+            this.removeKeyListener(keyOrKeys, tempListener);
+            resolve(null);
+          }, timeout)
+        : undefined;
 
       this.addKeyListener(keyOrKeys, tempListener, immediate);
     });

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3258,9 +3258,9 @@ export class EditorController extends ViewController {
   }
 
   async setupFromWindowLocation() {
-    this.sceneSettingsController.withSenderInfo({ senderID: this }, () =>
-      this._setupFromWindowLocation()
-    );
+    this.sceneSettingsController.withSenderInfo({ senderID: this }, async () => {
+      await this._setupFromWindowLocation();
+    });
   }
 
   async _setupFromWindowLocation() {

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -456,7 +456,7 @@ export class SceneController {
       }
 
       if (waitKeyBefore) {
-        await this.sceneSettingsController.waitForKeyChange(waitKeyBefore);
+        await this.sceneSettingsController.waitForKeyChange(waitKeyBefore, false, 20);
       }
 
       if (
@@ -480,7 +480,7 @@ export class SceneController {
       }
 
       if (waitKeyAfter) {
-        await this.sceneSettingsController.waitForKeyChange(waitKeyAfter);
+        await this.sceneSettingsController.waitForKeyChange(waitKeyAfter, false, 20);
       }
     }
   }


### PR DESCRIPTION
@qwerasd205 I'm pretty sure I found what you observed [here](https://github.com/fontra/fontra/pull/2660#issuecomment-4773917944): this started happening after navigating to the same or a different URL by selecting the navigator bar and hitting enter. 

There was a logic error that caused a promise to sometimes never resolve, and therefore a pushed stack item never got popped in a finally clause, which caused the URL to not be updated. Adding a timeout to waitForKeyChange fixed this.

(I made the timeout optional, but perhaps it should have a default value instead, to just always use the timeout.)