### PR TITLE
[glyphsets] Update GoogleFonts glyphsets

### DIFF
--- a/scripts/rebuild_glyphset_presets.py
+++ b/scripts/rebuild_glyphset_presets.py
@@ -20,20 +20,24 @@ def fetchJSON(url):
 
 # Unauthenticated: max. 60 request per hour, authenticated 5000 per hour
 # https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-unauthenticated-users
-def getGitHubDirectoryInfo(org, repo, path):
-    dirURL = f"https://api.github.com/repos/{org}/{repo}/contents/{path}"
+def getGitHubDirectoryInfo(org, repo, path, ref=None):
+    refString = f"?ref={ref}" if ref is not None else ""
+    dirURL = f"https://api.github.com/repos/{org}/{repo}/contents/{path}{refString}"
     return fetchJSON(dirURL)
 
 
-def jsDelivrURL(org, repo, path):
-    return f"https://cdn.jsdelivr.net/gh/{org}/{repo}/{path}"
+def jsDelivrURL(org, repo, path, ref=None):
+    refString = f"@{ref}" if ref is not None else ""
+    return f"https://cdn.jsdelivr.net/gh/{org}/{repo}{refString}/{path}"
 
 
 def getGoogleFontsGlyphSets():
     sourceURL = "https://github.com/googlefonts/glyphsets"
 
+    ref = None  # Can be a version tag or a branch name. For now: don't pin.
+
     dirContents = getGitHubDirectoryInfo(
-        "googlefonts", "glyphsets", "data/results/txt/nice-names/"
+        "googlefonts", "glyphsets", "data/results/txt/nice-names/", ref
     )
 
     glyphSets = []
@@ -45,7 +49,7 @@ def getGoogleFontsGlyphSets():
         glyphSets.append(
             {
                 "name": name,
-                "url": jsDelivrURL("googlefonts", "glyphsets", dirInfo["path"]),
+                "url": jsDelivrURL("googlefonts", "glyphsets", dirInfo["path"], ref),
             }
         )
 

--- a/src-js/fontra-core/assets/data/glyphset-presets.json
+++ b/src-js/fontra-core/assets/data/glyphset-presets.json
@@ -12,24 +12,76 @@
         "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Arabic_Core.txt"
       },
       {
+        "name": "GF Arabic Core Exclusive",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Arabic_Core_Exclusive.txt"
+      },
+      {
         "name": "GF Arabic Plus",
         "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Arabic_Plus.txt"
+      },
+      {
+        "name": "GF Arabic Plus Exclusive",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Arabic_Plus_Exclusive.txt"
       },
       {
         "name": "GF Cyrillic Core",
         "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Core.txt"
       },
       {
+        "name": "GF Cyrillic Core Exclusive",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Core_Exclusive.txt"
+      },
+      {
+        "name": "GF Cyrillic Core Italic Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Core_Italic_Localizations.txt"
+      },
+      {
+        "name": "GF Cyrillic Core Roman Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Core_Roman_Localizations.txt"
+      },
+      {
         "name": "GF Cyrillic Historical",
         "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Historical.txt"
+      },
+      {
+        "name": "GF Cyrillic Historical Italic Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Historical_Italic_Localizations.txt"
+      },
+      {
+        "name": "GF Cyrillic Historical Roman Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Historical_Roman_Localizations.txt"
       },
       {
         "name": "GF Cyrillic Plus",
         "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Plus.txt"
       },
       {
+        "name": "GF Cyrillic Plus Exclusive",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Plus_Exclusive.txt"
+      },
+      {
+        "name": "GF Cyrillic Plus Italic Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Plus_Italic_Localizations.txt"
+      },
+      {
+        "name": "GF Cyrillic Plus Roman Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Plus_Roman_Localizations.txt"
+      },
+      {
         "name": "GF Cyrillic Pro",
         "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Pro.txt"
+      },
+      {
+        "name": "GF Cyrillic Pro Exclusive",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Pro_Exclusive.txt"
+      },
+      {
+        "name": "GF Cyrillic Pro Italic Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Pro_Italic_Localizations.txt"
+      },
+      {
+        "name": "GF Cyrillic Pro Roman Localizations",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Cyrillic_Pro_Roman_Localizations.txt"
       },
       {
         "name": "GF Greek AncientMusicalSymbols",
@@ -46,6 +98,10 @@
       {
         "name": "GF Greek Core",
         "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Greek_Core.txt"
+      },
+      {
+        "name": "GF Greek Core Exclusive",
+        "url": "https://cdn.jsdelivr.net/gh/googlefonts/glyphsets/data/results/txt/nice-names/GF_Greek_Core_Exclusive.txt"
       },
       {
         "name": "GF Greek Expert",


### PR DESCRIPTION
This updates the GoogleFonts glyph sets to version 1.1.3, and fixes #2673 

Tangential:

I added the possibility to the fetch script to pin glyph sets to a github ref (tag/branch), but decided for now to not use this. It'll be confusing either way: "hmm my glyph sets contents changed" vs. "why do I see an old version". 

So I'll keep the status quo for now (while I ponder alternatives), that is:
- Use the directory content of the repos of the time that `scripts/rebuild_glyphset_presets.py` is run
- Fetch the content once a user activates a glyph set (or comes back later when a cache expires)

Result:
- If files are added to the repo, users will not see them until I run `scripts/rebuild_glyphset_presets.py` to rebuild the directory
- If files are deleted from the repo, there will likely be an error. I need to update the directory.
- If files are changed, users will see the changes as soon as the jsdelivr cache expires