### PR TITLE
[glyphcell enter key] Stop key event from propagating: this prevents a double invocation on Firefox

### DIFF
--- a/src-js/fontra-webcomponents/src/glyph-cell-view.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell-view.js
@@ -609,6 +609,8 @@ export class GlyphCellView extends HTMLElement {
     if (event.key in arrowKeyDeltas) {
       this.handleArrowKeys(event);
     } else if (event.key == "Enter") {
+      event.preventDefault();
+      event.stopImmediatePropagation();
       this.onOpenSelectedGlyphs?.(event);
     }
   }


### PR DESCRIPTION
This fixes #2678.