### PR TITLE
[font overview] Add "Copy Glyph Name(s) and "Copy Character(s)" context menus

### DIFF
--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "%0 Kontur schließen",
   "action.close-contour.plural": "%0 Konturen schließen",
   "action.copy": "Kopieren",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Ausschneiden",
   "action.decompose-component": "%0 Komponente auflösen",
   "action.decompose-component.plural": "%0 Komponenten auflösen",

--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "%0 Kontur schließen",
   "action.close-contour.plural": "%0 Konturen schließen",
   "action.copy": "Kopieren",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Ausschneiden",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Close %0 Contour",
   "action.close-contour.plural": "Close %0 Contours",
   "action.copy": "Copy",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Cut",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Close %0 Contour",
   "action.close-contour.plural": "Close %0 Contours",
   "action.copy": "Copy",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Cut",
   "action.decompose-component": "Decompose %0 Component",
   "action.decompose-component.plural": "Decompose %0 Components",

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Fermer %0 contour",
   "action.close-contour.plural": "Fermer %0 contours",
   "action.copy": "Copier",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Couper",
   "action.decompose-component": "Décomposer %0 composant",
   "action.decompose-component.plural": "Décomposer %0 composants",

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Fermer %0 contour",
   "action.close-contour.plural": "Fermer %0 contours",
   "action.copy": "Copier",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Couper",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "%0パスを閉じる",
   "action.close-contour.plural": "%0パスを閉じる",
   "action.copy": "コピー",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "カット",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "%0パスを閉じる",
   "action.close-contour.plural": "%0パスを閉じる",
   "action.copy": "コピー",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "カット",
   "action.decompose-component": "%0 を分解",
   "action.decompose-component.plural": "%0 を分解",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Sluit %0 contour",
   "action.close-contour.plural": "Sluit %0 contouren",
   "action.copy": "Kopiëer",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Snij",
   "action.decompose-component": "%0 component ontleden",
   "action.decompose-component.plural": "%0 componenten ontleden",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Sluit %0 contour",
   "action.close-contour.plural": "Sluit %0 contouren",
   "action.copy": "Kopiëer",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Snij",

--- a/src-js/fontra-core/assets/lang/tl.js
+++ b/src-js/fontra-core/assets/lang/tl.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Isara ang %0 Contour",
   "action.close-contour.plural": "Isara ang %0 na mga Contour",
   "action.copy": "Kopyahin",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Gupitin",
   "action.decompose-component": "I-decompose ang %0 na Bahagi",
   "action.decompose-component.plural": "Buwagin ang %0 na mga Bahagi",

--- a/src-js/fontra-core/assets/lang/tl.js
+++ b/src-js/fontra-core/assets/lang/tl.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "Isara ang %0 Contour",
   "action.close-contour.plural": "Isara ang %0 na mga Contour",
   "action.copy": "Kopyahin",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "Gupitin",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "闭合轮廓",
   "action.close-contour.plural": "闭合 %0 个轮廓",
   "action.copy": "复制",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "剪切",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "闭合轮廓",
   "action.close-contour.plural": "闭合 %0 个轮廓",
   "action.copy": "复制",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "剪切",
   "action.decompose-component": "释放部件",
   "action.decompose-component.plural": "释放 %0 个部件",

--- a/src-js/fontra-core/assets/lang/zh-TW.js
+++ b/src-js/fontra-core/assets/lang/zh-TW.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "閉合輪廓",
   "action.close-contour.plural": "閉合 %0 個輪廓",
   "action.copy": "複製",
+  "action.copy-glyphname": "Copy Glyph Name",
+  "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "剪下",
   "action.decompose-component": "釋放部件",
   "action.decompose-component.plural": "釋放 %0 個部件",

--- a/src-js/fontra-core/assets/lang/zh-TW.js
+++ b/src-js/fontra-core/assets/lang/zh-TW.js
@@ -21,6 +21,8 @@ export const strings = {
   "action.close-contour": "閉合輪廓",
   "action.close-contour.plural": "閉合 %0 個輪廓",
   "action.copy": "複製",
+  "action.copy-character": "Copy Character",
+  "action.copy-character.plural": "Copy Characters",
   "action.copy-glyphname": "Copy Glyph Name",
   "action.copy-glyphname.plural": "Copy Glyph Names",
   "action.cut": "剪下",

--- a/src-js/fontra-core/src/fontra-menus.js
+++ b/src-js/fontra-core/src/fontra-menus.js
@@ -270,6 +270,11 @@ function rerouteViewPath(path, targetView) {
     defaultShortCuts: [{ baseKey: "c", commandKey: true }],
   });
 
+  registerActionInfo("action.copy-glyphname", {
+    topic,
+    defaultShortCuts: [{ baseKey: "c", commandKey: true, shiftKey: true }],
+  });
+
   registerActionInfo("action.paste", {
     topic,
     defaultShortCuts: [{ baseKey: "v", commandKey: true }],

--- a/src-js/fontra-core/src/fontra-menus.js
+++ b/src-js/fontra-core/src/fontra-menus.js
@@ -275,6 +275,13 @@ function rerouteViewPath(path, targetView) {
     defaultShortCuts: [{ baseKey: "c", commandKey: true, shiftKey: true }],
   });
 
+  registerActionInfo("action.copy-character", {
+    topic,
+    defaultShortCuts: [
+      { baseKey: "c", commandKey: true, shiftKey: true, altKey: true },
+    ],
+  });
+
   registerActionInfo("action.paste", {
     topic,
     defaultShortCuts: [{ baseKey: "v", commandKey: true }],

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -20,7 +20,7 @@ import {
 } from "@fontra/core/glyphsets-controller.js";
 import * as html from "@fontra/core/html-utils.js";
 import { loaderSpinner } from "@fontra/core/loader-spinner.js";
-import { translate } from "@fontra/core/localization.js";
+import { translate, translatePlural } from "@fontra/core/localization.js";
 import { ObservableController } from "@fontra/core/observable-object.ts";
 import { labeledTextInput } from "@fontra/core/ui-utils.js";
 import {
@@ -116,6 +116,7 @@ export class FontOverviewController extends ViewController {
       MenuItemDivider,
       { actionIdentifier: "action.cut" }, // TODO: see comment below
       { actionIdentifier: "action.copy" },
+      { actionIdentifier: "action.copy-glyphname" },
       { actionIdentifier: "action.paste" },
       { actionIdentifier: "action.delete" },
       MenuItemDivider,
@@ -445,6 +446,17 @@ export class FontOverviewController extends ViewController {
     );
 
     registerActionCallbacks(
+      "action.copy-glyphname",
+      () => this.doCopyGlyphNames(),
+      () => !!this.glyphCellView.glyphSelection?.size,
+      () =>
+        translatePlural(
+          "action.copy-glyphname",
+          this.glyphCellView.glyphSelection?.size ?? 0
+        )
+    );
+
+    registerActionCallbacks(
       "action.paste",
       () => this.doPaste(),
       () => this.canPaste()
@@ -625,6 +637,12 @@ export class FontOverviewController extends ViewController {
     );
 
     return { svgString, glifString };
+  }
+
+  async doCopyGlyphNames() {
+    await writeToClipboard({
+      "text/plain": Array.from(this.glyphCellView.glyphSelection).join(" "),
+    });
   }
 
   canPaste() {

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -116,9 +116,11 @@ export class FontOverviewController extends ViewController {
       MenuItemDivider,
       { actionIdentifier: "action.cut" }, // TODO: see comment below
       { actionIdentifier: "action.copy" },
-      { actionIdentifier: "action.copy-glyphname" },
       { actionIdentifier: "action.paste" },
       { actionIdentifier: "action.delete" },
+      MenuItemDivider,
+      { actionIdentifier: "action.copy-glyphname" },
+      { actionIdentifier: "action.copy-character" },
       MenuItemDivider,
       { actionIdentifier: "action.select-all" },
       { actionIdentifier: "action.select-none" },
@@ -457,6 +459,17 @@ export class FontOverviewController extends ViewController {
     );
 
     registerActionCallbacks(
+      "action.copy-character",
+      () => this.doCopyCharacters(),
+      () => !!this.glyphCellView.glyphSelection?.size,
+      () =>
+        translatePlural(
+          "action.copy-character",
+          this.glyphCellView.glyphSelection?.size ?? 0
+        )
+    );
+
+    registerActionCallbacks(
       "action.paste",
       () => this.doPaste(),
       () => this.canPaste()
@@ -642,6 +655,20 @@ export class FontOverviewController extends ViewController {
   async doCopyGlyphNames() {
     await writeToClipboard({
       "text/plain": Array.from(this.glyphCellView.glyphSelection).join(" "),
+    });
+  }
+
+  async doCopyCharacters() {
+    const { combinedGlyphMap } = await this.glyphSetsController.getCombinedGlyphMap(
+      this._fontGlyphItemList
+    );
+
+    await writeToClipboard({
+      "text/plain": Array.from(this.glyphCellView.glyphSelection)
+        .map((glyphName) => combinedGlyphMap[glyphName][0])
+        .filter((codePoint) => codePoint)
+        .map((codePoint) => String.fromCodePoint(codePoint))
+        .join(""),
     });
   }
 

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -483,10 +483,12 @@ export class FontOverviewController extends ViewController {
 
     registerActionCallbacks(
       "action.select-all",
-      () =>
-        (this.glyphCellView.glyphSelection = new Set(
-          Object.keys(this.fontController.glyphMap)
-        )),
+      async () => {
+        const { combinedGlyphMap } = await this.glyphSetsController.getCombinedGlyphMap(
+          this._fontGlyphItemList
+        );
+        this.glyphCellView.glyphSelection = new Set(Object.keys(combinedGlyphMap));
+      },
       () => true
     );
 


### PR DESCRIPTION
This fixes #2676.

Additionally, this changes the behavior of "Select All" to really select all, and not skip glyphs that aren't in the font (but are in the combined selected glyph sets).