### PR TITLE
Fix zoom in/out behavior when there is no selection

### DIFF
--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3425,7 +3425,7 @@ export class EditorController extends ViewController {
 
   _zoom(factor) {
     let viewBox = this.sceneSettings.viewBox;
-    const selBox = this.sceneController.getSelectionBounds();
+    const selBox = this.sceneController.getSelectionBounds(false);
     const center = rectCenter(selBox || viewBox);
     viewBox = rectScaleAroundCenter(viewBox, factor, center);
 

--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -1553,8 +1553,8 @@ export class SceneController {
     return addSourceChanges;
   }
 
-  getSelectionBounds() {
-    return this.sceneModel.getSelectionBounds();
+  getSelectionBounds(considerSceneBounds = true) {
+    return this.sceneModel.getSelectionBounds(considerSceneBounds);
   }
 
   getUndoRedoInfo(isRedo) {

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -1204,9 +1204,9 @@ export class SceneModel {
     return bounds;
   }
 
-  getSelectionBounds() {
+  getSelectionBounds(considerSceneBounds = true) {
     if (!this.selectedGlyph) {
-      return this.getSceneBounds();
+      return considerSceneBounds ? this.getSceneBounds() : null;
     }
 
     let bounds;


### PR DESCRIPTION
Fix zoom in/out behavior when there is no selection at all: use the view box center in that case, instead of the scene box center

This fixes #2686.