### PR TITLE
[fontoverview] Fix "delete" shortcut in glyph cell view

### DIFF
--- a/src-js/fontra-webcomponents/src/glyph-cell-view.js
+++ b/src-js/fontra-webcomponents/src/glyph-cell-view.js
@@ -1,3 +1,4 @@
+import { getActionIdentifierFromKeyEvent } from "@fontra/core/actions.js";
 import * as html from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import {
@@ -705,7 +706,8 @@ export class GlyphCellView extends HTMLElement {
       this.onOpenSelectedGlyphs?.(event);
     } else if (
       !(event.metaKey || event.ctrlKey) &&
-      event.target !== this.hiddenTextEntry
+      event.target !== this.hiddenTextEntry &&
+      !getActionIdentifierFromKeyEvent(event)
     ) {
       event.stopImmediatePropagation();
       const keyEvent = new event.constructor(event.type, event);


### PR DESCRIPTION
It stopped working with the "select-a-glyph-by-typing-a-glyphname-or-character" functionality (#2682).

Fix the problem by making sure we don't hide registered shortcuts in the keydown event handler.