### PR TITLE
Ensure the isSparse field is filled in, so we can interpolate after toggling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixes
 
+- Fix bug with font source interpolation after toggling the "Is Sparse" flag. [PR 2693](https://github.com/fontra/fontra/pull/2693)
 - [font overview, Firefox] Prevent opening two tabs instead of one when typing Enter to open the selection in the glyph editor. [Issue 2678](https://github.com/fontra/fontra/issues/2678) [PR 2680](https://github.com/fontra/fontra/pull/2680)
 
 ## 2026-06-28 [version 2026.6.5]

--- a/src-js/fontra-core/src/font-controller.js
+++ b/src-js/fontra-core/src/font-controller.js
@@ -1390,6 +1390,7 @@ function ensureDenseSources(sources) {
 export function ensureDenseSource(source) {
   return {
     ...source,
+    isSparse: !!source.isSparse,
     location: source.location || {},
     lineMetricsHorizontalLayout: mapObjectValues(
       source.lineMetricsHorizontalLayout || {},


### PR DESCRIPTION
This fixes font source interpolation when toggling a sparse source to not sparse: this would fail because the untouched sources would not contain the `isSparse` field.