### PR TITLE
Fix long menus

### DIFF
--- a/src-js/fontra-webcomponents/src/menu-panel.js
+++ b/src-js/fontra-webcomponents/src/menu-panel.js
@@ -35,7 +35,7 @@ export class MenuPanel extends SimpleElement {
     if (event.target?.closest?.("menu-bar")) {
       return;
     }
-    for (const element of MenuPanel.openMenuPanels) {
+    for (const element of Array.from(MenuPanel.openMenuPanels)) {
       element.dismiss();
       if (element.context === "menu-bar" && !element.childOf) {
         dispatchCustomEvent(window, "menu-bar:close-menu");
@@ -65,6 +65,8 @@ export class MenuPanel extends SimpleElement {
       font-size: 1rem;
       user-select: none;
       cursor: default;
+      max-height: calc(100vh - 0.3em);
+      overflow: auto;
     }
 
     .menu-container {
@@ -261,6 +263,8 @@ export class MenuPanel extends SimpleElement {
           ]),
         ];
 
+        let didSeeMouseDown = false;
+
         itemElement = html.div(
           {
             class: classNames.join(" "),
@@ -271,6 +275,7 @@ export class MenuPanel extends SimpleElement {
               }
             },
             onmousedown: (event) => {
+              didSeeMouseDown = true;
               event.preventDefault();
               event.stopImmediatePropagation();
             },
@@ -278,6 +283,14 @@ export class MenuPanel extends SimpleElement {
               this.selectItem(null);
             },
             onmouseup: (event) => {
+              if (
+                !mouseMovedWhileDown &&
+                !didSeeMouseDown &&
+                event.type !== "keydown"
+              ) {
+                return;
+              }
+              didSeeMouseDown = false;
               event.preventDefault();
               event.stopImmediatePropagation();
               if (item.enabled()) {
@@ -335,15 +348,14 @@ export class MenuPanel extends SimpleElement {
       item.classList.add("selected");
 
       if (item.classList.contains("with-submenu")) {
-        const { y } = this.getBoundingClientRect();
         const itemRect = item.getBoundingClientRect();
 
         this.submenu = new MenuPanel(this.menuItems[item.dataset.index].getItems(), {
           hidden: true,
           immediatelyActive: false,
           position: {
-            x: itemRect.width,
-            y: itemRect.y - y - 4,
+            x: itemRect.right,
+            y: itemRect.y - 3.5,
           },
           childOf: this,
           context: this.context,
@@ -352,12 +364,18 @@ export class MenuPanel extends SimpleElement {
             this.dismiss();
           },
         });
-        this.menuElement.appendChild(this.submenu);
+        document.body.appendChild(this.submenu);
         if (!fromChild) {
           this.submenu.show({ animated: true });
         }
         item.classList.add("has-open-submenu");
       }
+
+      item.scrollIntoView({
+        behavior: "auto",
+        block: "nearest",
+        inline: "nearest",
+      });
     }
   }
 
@@ -469,6 +487,11 @@ customElements.define("menu-panel", MenuPanel);
 
 window.addEventListener("blur", (event) => MenuPanel.closeMenuPanels(event));
 window.addEventListener("mousedown", (event) => MenuPanel.closeMenuPanels(event));
+
+let mouseMovedWhileDown = false;
+window.addEventListener("mousemove", (event) => {
+  mouseMovedWhileDown = !!event.buttons;
+});
 
 function getMenuContainer() {
   // This is tightly coupled to modal-dialog.js


### PR DESCRIPTION
- set max-height for menu panels
- make then scroll when needed
- don't attach submenu to the menu panel itself: it prevents correct scrolling
- make click on an overlong menu panel not immediately select the item that happens to be right at of the cursor

This fixes behavior when a menu panel contains more items than fits in the view port.