### PR TITLE
Fix submenu dismiss in menu bar

### DIFF
--- a/src-js/fontra-webcomponents/src/menu-bar.js
+++ b/src-js/fontra-webcomponents/src/menu-bar.js
@@ -126,6 +126,7 @@ export class MenuBar extends SimpleElement {
     if (this.currentSelection) {
       this.currentSelection.classList.remove("current");
       if (this.menuPanel) {
+        this.submenuPanel?.dismiss();
         this.contentElement.removeChild(this.menuPanel);
       }
     }

--- a/src-js/fontra-webcomponents/src/menu-panel.js
+++ b/src-js/fontra-webcomponents/src/menu-panel.js
@@ -338,7 +338,7 @@ export class MenuPanel extends SimpleElement {
     }
 
     if (item) {
-      for (const panel of MenuPanel.openMenuPanels) {
+      for (const panel of Array.from(MenuPanel.openMenuPanels)) {
         panel.setActive(panel === this);
         if (panel.childOf === this) {
           panel.dismiss();


### PR DESCRIPTION
This fixes a regression caused by #2694: sometimes a submenu would not go away when hovering elsewhere.