### PR TITLE
[designspace] Write features to all UFOs, not just the default

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -1524,11 +1524,9 @@ class DesignspaceBackend(WatchableBackend, WritableBaseBackend):
             return
 
         paths = sorted(set(self.ufoLayers.iterAttrs("path")))
-        defaultPath = self.defaultUFOLayer.path if paths else None
         for path in paths:
             writer = self.ufoManager.getWriter(path)
-            featureText = features.text if path == defaultPath else ""
-            writer.writeFeatures(featureText)
+            writer.writeFeatures(features.text)
             self.fileWatcherIgnoreNextChange(os.path.join(path, FEATURES_FILENAME))
 
         self.resetGlyphDirections()


### PR DESCRIPTION
While features in *only* the default UFO should work (other UFOs containing no features), there seems to be an edge case with languagesystem detection. I have a font that doesn't compile this way. Writing features to all UFOs fixes this. I need to dig deeper to figure out the true reason the "features-only-in-the default-UFO" way doesn't work in this case.