### PR TITLE
Deep copy anchors when adding them to a glyph: they may not be unique objects

### DIFF
--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -38,6 +38,7 @@ import { getDecomposedIdentity } from "@fontra/core/transform.js";
 import { labeledCheckbox, labeledTextInput, pickFile } from "@fontra/core/ui-utils.js";
 import {
   commandKeyProperty,
+  deepCopyObject,
   enumerate,
   eventIsCausedByWritingURLFragment,
   fetchJSON,
@@ -2201,8 +2202,8 @@ export class EditorController extends ViewController {
             defaultPasteGlyph;
           layerGlyph.path.appendPath(pasteGlyph.path);
           layerGlyph.components.push(...pasteGlyph.components.map(copyComponent));
-          layerGlyph.anchors.push(...pasteGlyph.anchors);
-          layerGlyph.guidelines.push(...pasteGlyph.guidelines);
+          layerGlyph.anchors.push(...pasteGlyph.anchors.map(deepCopyObject));
+          layerGlyph.guidelines.push(...pasteGlyph.guidelines.map(deepCopyObject));
           if (pasteGlyph.backgroundImage) {
             layerGlyph.backgroundImage = pasteGlyph.backgroundImage;
             if (!this.sceneSettings.backgroundImagesAreLocked) {


### PR DESCRIPTION
This fixes #2705, and fixes the same problem for guidelines: by copying the objects we prevent unintentional "linking" (pasting the exact same object multiple times, shared across several sources).