### PR TITLE
Fix glyphset ambiguities

### DIFF
--- a/src-js/fontra-core/src/glyphsets-controller.js
+++ b/src-js/fontra-core/src/glyphsets-controller.js
@@ -2,7 +2,12 @@ import { getGlyphMapProxy } from "./cmap.js";
 import { translate } from "./localization.js";
 import { ObservableController } from "./observable-object.ts";
 import { parseGlyphSet, redirectGlyphSetURL } from "./parse-glyphset.js";
-import { assert, friendlyHttpStatus, sleepAsync } from "./utils.ts";
+import {
+  assert,
+  disambiguateGlyphName,
+  friendlyHttpStatus,
+  sleepAsync,
+} from "./utils.ts";
 
 export const THIS_FONTS_GLYPHSET = "";
 export const PROJECT_GLYPH_SETS_CUSTOM_DATA_KEY = "fontra.projectGlyphSets";
@@ -285,16 +290,4 @@ function getMyGlyphSetsController() {
 
 export function getMyGlyphSets() {
   return myGlyphSetsController.model.settings;
-}
-
-function disambiguateGlyphName(glyphName, referenceObject) {
-  let count = 0;
-  let suffix;
-
-  do {
-    suffix = `.alt${count ? count : ""}`;
-    count++;
-  } while (glyphName + suffix in referenceObject);
-
-  return glyphName + suffix;
 }

--- a/src-js/fontra-core/src/glyphsets-controller.js
+++ b/src-js/fontra-core/src/glyphsets-controller.js
@@ -22,8 +22,10 @@ export class GlyphSetsController {
 
   async getCombinedGlyphMap(fontGlyphItemList) {
     /*
-      Merge selected glyph sets. When multiple glyph sets define a character
-      but the glyph name does not match:
+      Merge selected glyph sets.
+
+      When multiple glyph sets define a character but the glyph name does not
+      match:
       - If the font defines this character, take the font's glyph name for it
       - Else take the glyph name from the first glyph set that defines the
         character
@@ -31,8 +33,13 @@ export class GlyphSetsController {
       should be sorted.
       If the conflicting glyph name references multiple code points, we bail,
       as it is not clear how to resolve.
+
+      When a glyph set defines a glyph name, and a glyph by that name exists in
+      the font, but the code points do not match between them:
+      - Disambiguate the glyph name by adding a suffix: .alt, .alt1, .alt2 etc.
     */
     const fontCharacterMap = this.fontController.characterMap;
+    const fontGlyphMap = this.fontController.glyphMap;
     const combinedCharacterMap = {};
     const combinedGlyphMap = getGlyphMapProxy({}, combinedCharacterMap);
 
@@ -53,18 +60,27 @@ export class GlyphSetsController {
     ).filter((glyphSet) => glyphSet);
 
     for (const glyphSet of glyphSets) {
-      for (const { glyphName, codePoints } of glyphSet) {
+      for (let { glyphName, codePoints } of glyphSet) {
         const singleCodePoint = codePoints.length === 1 ? codePoints[0] : null;
-        const foundGlyphName =
-          singleCodePoint !== null
-            ? combinedCharacterMap[singleCodePoint] || fontCharacterMap[singleCodePoint]
-            : null;
 
-        if (foundGlyphName) {
-          if (!combinedGlyphMap[foundGlyphName]) {
-            combinedGlyphMap[foundGlyphName] = codePoints;
-          }
-        } else if (!combinedGlyphMap[glyphName]) {
+        glyphName =
+          singleCodePoint !== null
+            ? (combinedCharacterMap[singleCodePoint] ??
+              fontCharacterMap[singleCodePoint] ??
+              glyphName)
+            : glyphName;
+
+        if (
+          singleCodePoint !== null &&
+          glyphName in fontGlyphMap &&
+          fontCharacterMap[singleCodePoint] != glyphName
+        ) {
+          // The glyph exists in the font, but it is encoded differently than in the
+          // current glyph set. We need to change the glyph name to prevent confusion.
+          glyphName = disambiguateGlyphName(glyphName, fontGlyphMap);
+        }
+
+        if (!combinedGlyphMap[glyphName]) {
           combinedGlyphMap[glyphName] = codePoints;
         }
       }
@@ -269,4 +285,16 @@ function getMyGlyphSetsController() {
 
 export function getMyGlyphSets() {
   return myGlyphSetsController.model.settings;
+}
+
+function disambiguateGlyphName(glyphName, referenceObject) {
+  let count = 0;
+  let suffix;
+
+  do {
+    suffix = `.alt${count ? count : ""}`;
+    count++;
+  } while (glyphName + suffix in referenceObject);
+
+  return glyphName + suffix;
 }

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -1055,3 +1055,18 @@ export function parseDataURL(dataURL: string) {
 export function objectsEqualSerialized(a: any, b: any) {
   return JSON.stringify(a) === JSON.stringify(b);
 }
+
+export function disambiguateGlyphName(
+  glyphName: string,
+  referenceObject: Record<string, any>
+) {
+  let count = 0;
+  let suffix;
+
+  do {
+    suffix = `.alt${count ? count : ""}`;
+    count++;
+  } while (glyphName + suffix in referenceObject);
+
+  return glyphName + suffix;
+}

--- a/src-js/fontra-core/src/utils.ts
+++ b/src-js/fontra-core/src/utils.ts
@@ -1061,12 +1061,12 @@ export function disambiguateGlyphName(
   referenceObject: Record<string, any>
 ) {
   let count = 0;
-  let suffix;
+  let suffix = "";
 
-  do {
+  while (glyphName + suffix in referenceObject) {
     suffix = `.alt${count ? count : ""}`;
     count++;
-  } while (glyphName + suffix in referenceObject);
+  }
 
   return glyphName + suffix;
 }

--- a/src-js/fontra-core/tests/test-utils.js
+++ b/src-js/fontra-core/tests/test-utils.js
@@ -7,6 +7,7 @@ import {
   clamp,
   compare,
   consolidateCalls,
+  disambiguateGlyphName,
   dumpURLFragment,
   enumerate,
   fileNameExtension,
@@ -798,5 +799,22 @@ describe("compare", () => {
 
   parametrize("compare test", testData, (testCase) => {
     expect(compare(testCase.a, testCase.b)).to.equal(testCase.result);
+  });
+});
+
+describe("disambiguateGlyphName", () => {
+  const testData = [
+    { name: "A", reference: {}, result: "A" },
+    { name: "A", reference: { A: null }, result: "A.alt" },
+    { name: "A", reference: { "A": null, "A.alt": null }, result: "A.alt1" },
+    {
+      name: "A",
+      reference: { "A": null, "A.alt": null, "A.alt1": null },
+      result: "A.alt2",
+    },
+  ];
+
+  parametrize("compare test", testData, ({ name, reference, result }) => {
+    expect(disambiguateGlyphName(name, reference)).to.equal(result);
   });
 });

--- a/src-js/views-editor/src/panel-selection-info.js
+++ b/src-js/views-editor/src/panel-selection-info.js
@@ -39,6 +39,7 @@ export default class SelectionInfoPanel extends Panel {
         "fontLocationSourceMapped",
         "glyphLocation",
         "editLayerName",
+        "combinedCharacterMap",
       ],
       (event) => this.throttledUpdate()
     );

--- a/src-js/views-editor/src/scene-model.js
+++ b/src-js/views-editor/src/scene-model.js
@@ -25,6 +25,7 @@ import { decomposedToTransform } from "@fontra/core/transform.js";
 import {
   assert,
   consolidateCalls,
+  disambiguateGlyphName,
   enumerate,
   mapObjectKeys,
   objectsEqualSerialized,
@@ -1338,7 +1339,10 @@ class LineSetter {
         glyphInfo.codepoint != 0 || fallbackCodePoint >= MAX_UNICODE
           ? glyphInfo.glyphname
           : (fallbackCharacterMap[fallbackCodePoint] ??
-            getSuggestedGlyphName(fallbackCodePoint));
+            disambiguateGlyphName(
+              getSuggestedGlyphName(fallbackCodePoint),
+              fontController.glyphMap
+            ));
 
       const isSelectedGlyph = glyphIndex == selectedGlyphIndex;
 


### PR DESCRIPTION
If a character is not encoded by the font, but the suggested glyph name *is* defined, Fontra used to get confused.

This PR disambiguates the glyph name for the undefined character to ensure that glyph name does not exist in the font.

Cases:
- accidentally unencoded glyph
- glyph encoded different from the "canonical" encoding