### PR TITLE
Optionally show handles and nodes in background layers

### DIFF
--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -508,6 +508,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Glyph-Editor Ansicht",
   "sidebar.user-settings.glyph.anchornames": "Anker Namen",
   "sidebar.user-settings.glyph.background-image": "Hintergrund-Bild",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Grundlinie",
   "sidebar.user-settings.glyph.cjkframe": "CJK Design Rahmen",
   "sidebar.user-settings.glyph.component": "Komponenten-Namen und -Indexe",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -498,6 +498,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Glyph editor appearance",
   "sidebar.user-settings.glyph.anchornames": "Anchor names",
   "sidebar.user-settings.glyph.background-image": "Background image",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Baseline",
   "sidebar.user-settings.glyph.cjkframe": "CJK Design Frame",
   "sidebar.user-settings.glyph.component": "Component names and indices",

--- a/src-js/fontra-core/assets/lang/es-419.js
+++ b/src-js/fontra-core/assets/lang/es-419.js
@@ -523,6 +523,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Apariencia del editor de glifos",
   "sidebar.user-settings.glyph.anchornames": "Nombres de anclas",
   "sidebar.user-settings.glyph.background-image": "Imagen de fondo",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Línea de base",
   "sidebar.user-settings.glyph.cjkframe": "Marco de diseño CJK",
   "sidebar.user-settings.glyph.component": "Nombres e índices de componentes",

--- a/src-js/fontra-core/assets/lang/es-ES.js
+++ b/src-js/fontra-core/assets/lang/es-ES.js
@@ -523,6 +523,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Apariencia del editor de glifos",
   "sidebar.user-settings.glyph.anchornames": "Nombres de anclas",
   "sidebar.user-settings.glyph.background-image": "Imagen de fondo",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Línea de base",
   "sidebar.user-settings.glyph.cjkframe": "Marco de diseño CJK",
   "sidebar.user-settings.glyph.component": "Nombres e índices de componentes",

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -532,6 +532,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Apparence de l'éditeur de glyphes",
   "sidebar.user-settings.glyph.anchornames": "Noms d'ancrage",
   "sidebar.user-settings.glyph.background-image": "Image d'arrière-plan",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Ligne de base",
   "sidebar.user-settings.glyph.cjkframe": "Cadre de conception CJK",
   "sidebar.user-settings.glyph.component": "Noms et indices des composants",

--- a/src-js/fontra-core/assets/lang/it.js
+++ b/src-js/fontra-core/assets/lang/it.js
@@ -531,6 +531,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Aspetto dell'editor di glifi",
   "sidebar.user-settings.glyph.anchornames": "Nomi delle ancore",
   "sidebar.user-settings.glyph.background-image": "Immagine di sfondo",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Linea di base",
   "sidebar.user-settings.glyph.cjkframe": "Frame di progettazione CJK",
   "sidebar.user-settings.glyph.component": "Nomi e indici dei componenti",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -501,6 +501,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "グリフエディターの表示設定",
   "sidebar.user-settings.glyph.anchornames": "アンカー名を表示",
   "sidebar.user-settings.glyph.background-image": "背景画像を表示",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "ベースラインを表示",
   "sidebar.user-settings.glyph.cjkframe": "CJKデザインフレームを表示",
   "sidebar.user-settings.glyph.component": "コンポーネント名とシェイプの順番を表示",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -510,6 +510,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Glyph editor uiterlijk",
   "sidebar.user-settings.glyph.anchornames": "Ankernamen",
   "sidebar.user-settings.glyph.background-image": "Achtergrondafbeelding",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Basislijn",
   "sidebar.user-settings.glyph.cjkframe": "CJK Design Frame",
   "sidebar.user-settings.glyph.component": "Component namen en indexen",

--- a/src-js/fontra-core/assets/lang/pt-BR.js
+++ b/src-js/fontra-core/assets/lang/pt-BR.js
@@ -526,6 +526,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Aparência do editor de glifos",
   "sidebar.user-settings.glyph.anchornames": "Nome das âncoras",
   "sidebar.user-settings.glyph.background-image": "Imagem de fundo",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Linha de base",
   "sidebar.user-settings.glyph.cjkframe": "Moldura de design CJK",
   "sidebar.user-settings.glyph.component": "Nomes e índices dos componentes",

--- a/src-js/fontra-core/assets/lang/pt-PT.js
+++ b/src-js/fontra-core/assets/lang/pt-PT.js
@@ -526,6 +526,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Aparência do editor de glifos",
   "sidebar.user-settings.glyph.anchornames": "Nome das âncoras",
   "sidebar.user-settings.glyph.background-image": "Imagem de fundo",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Linha de base",
   "sidebar.user-settings.glyph.cjkframe": "Moldura de design CJK",
   "sidebar.user-settings.glyph.component": "Nomes e índices dos componentes",

--- a/src-js/fontra-core/assets/lang/tl.js
+++ b/src-js/fontra-core/assets/lang/tl.js
@@ -519,6 +519,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "Hitsura ng editor ng Glyph",
   "sidebar.user-settings.glyph.anchornames": "Mga pangalan ng angkla",
   "sidebar.user-settings.glyph.background-image": "Larawan sa background",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "Baseline",
   "sidebar.user-settings.glyph.cjkframe": "Disenyo ng Frame ng CJK",
   "sidebar.user-settings.glyph.component": "Mga pangalan at indeks ng bahagi",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -474,6 +474,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "字形编辑器外观",
   "sidebar.user-settings.glyph.anchornames": "锚点名称",
   "sidebar.user-settings.glyph.background-image": "背景图片",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "基线",
   "sidebar.user-settings.glyph.cjkframe": "汉字字面框",
   "sidebar.user-settings.glyph.component": "部件名称与序号",

--- a/src-js/fontra-core/assets/lang/zh-TW.js
+++ b/src-js/fontra-core/assets/lang/zh-TW.js
@@ -475,6 +475,8 @@ export const strings = {
   "sidebar.user-settings.glyph": "字形編輯器外觀",
   "sidebar.user-settings.glyph.anchornames": "錨點名稱",
   "sidebar.user-settings.glyph.background-image": "背景圖片",
+  "sidebar.user-settings.glyph.background-nodes-and-handles":
+    "Nodes and handles for background layers",
   "sidebar.user-settings.glyph.baseline": "基線",
   "sidebar.user-settings.glyph.cjkframe": "漢字字面框",
   "sidebar.user-settings.glyph.component": "部件名稱及序號",

--- a/src-js/views-editor/src/visualization-layer-definitions.js
+++ b/src-js/views-editor/src/visualization-layer-definitions.js
@@ -1544,6 +1544,67 @@ registerVisualizationLayerDefinition({
 });
 
 registerVisualizationLayerDefinition({
+  identifier: "fontra.edit.background.layers.nodes-and-handles",
+  name: "sidebar.user-settings.glyph.background-nodes-and-handles",
+  userSwitchable: true,
+  defaultOn: false,
+  selectionFunc: glyphSelector("editing"),
+  zIndex: 490,
+  screenParameters: {
+    strokeWidth: 0.5,
+    cornerSize: 5.5,
+    smoothSize: 5.5,
+    handleSize: 4.5,
+  },
+  colors: { backgroundColor: "#DDDF", editColor: "#BBFF" },
+  colorsDarkMode: { backgroundColor: "#555F", editColor: "#559F" },
+
+  draw: (context, positionedGlyph, parameters, model, controller) => {
+    context.lineWidth = parameters.strokeWidth;
+
+    context.strokeStyle = parameters.backgroundColor;
+    context.fillStyle = parameters.backgroundColor;
+
+    drawBackgroundHandlesAndNodes(
+      context,
+      Object.values(model.backgroundLayerGlyphs || {}),
+      parameters.cornerSize,
+      parameters.smoothSize,
+      parameters.handleSize
+    );
+
+    context.strokeStyle = parameters.editColor;
+    context.fillStyle = parameters.editColor;
+
+    drawBackgroundHandlesAndNodes(
+      context,
+      Object.values(model.editingLayerGlyphs || {}),
+      parameters.cornerSize,
+      parameters.smoothSize,
+      parameters.handleSize
+    );
+  },
+});
+
+function drawBackgroundHandlesAndNodes(
+  context,
+  glyphs,
+  cornerSize,
+  smoothSize,
+  handleSize
+) {
+  for (const glyph of glyphs) {
+    for (const [pt1, pt2] of glyph.path.iterHandles()) {
+      strokeLine(context, pt1.x, pt1.y, pt2.x, pt2.y);
+    }
+
+    for (const pt of glyph.path.iterPoints()) {
+      fillNode(context, pt, cornerSize, smoothSize, handleSize);
+    }
+  }
+}
+
+registerVisualizationLayerDefinition({
   identifier: "fontra.edit.background.layers",
   name: "Background glyph layers",
   selectionFunc: glyphSelector("editing"),
@@ -1552,8 +1613,8 @@ registerVisualizationLayerDefinition({
     strokeWidth: 1,
     anchorRadius: 4,
   },
-  colors: { color: "#AAA8", colorAnchor: "#AAA7" },
-  colorsDarkMode: { color: "#8888", colorAnchor: "#8887" },
+  colors: { color: "#CCCF", colorAnchor: "#DDDF" },
+  colorsDarkMode: { color: "#666F", colorAnchor: "#555F" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     context.lineJoin = "round";
     context.lineWidth = parameters.strokeWidth;
@@ -1579,8 +1640,8 @@ registerVisualizationLayerDefinition({
     strokeWidth: 1,
     anchorRadius: 4,
   },
-  colors: { color: "#66FA", colorAnchor: "#66F5" },
-  colorsDarkMode: { color: "#88FA", colorAnchor: "#88F7" },
+  colors: { color: "#99FF", colorAnchor: "#AAFF" },
+  colorsDarkMode: { color: "#559F", colorAnchor: "#558F" },
   draw: (context, positionedGlyph, parameters, model, controller) => {
     const primaryEditingInstance = positionedGlyph.glyph;
     context.lineJoin = "round";


### PR DESCRIPTION
Where "background layers" includes "edit layers".

This adds a menu item to "View -> Glyph editor appearance" with the title: "Nodes and handles for background layers"