### PR TITLE
Misc menu fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- Fix the menu item background color in dark mode when the item has a submenu; Don't dismiss a menu panel when clicking on an item with a submenu. [PR 2739](https://github.com/fontra/fontra/pull/2739)
 - Fixes behavior when a character is not encoded, but the (suggested) glyph name for it does exist in the font. [PR 2724](https://github.com/fontra/fontra/pull/2724)
 
 ### Improvements

--- a/src-js/fontra-webcomponents/src/menu-panel.js
+++ b/src-js/fontra-webcomponents/src/menu-panel.js
@@ -48,6 +48,7 @@ export class MenuPanel extends SimpleElement {
     "foreground-color": ["black", "white"],
     "background-active-color": ["var(--fontra-red-color)", "var(--fontra-red-color)"],
     "foreground-active-color": ["white", "white"],
+    "background-color-with-open-submenu": ["#dedede", "#555"],
   };
 
   static styles = `
@@ -90,7 +91,7 @@ export class MenuPanel extends SimpleElement {
     }
 
     .has-open-submenu {
-      background-color: #dedede;
+      background-color: var(--background-color-with-open-submenu);
     }
 
     .context-menu-item.enabled {

--- a/src-js/fontra-webcomponents/src/menu-panel.js
+++ b/src-js/fontra-webcomponents/src/menu-panel.js
@@ -293,7 +293,7 @@ export class MenuPanel extends SimpleElement {
               didSeeMouseDown = false;
               event.preventDefault();
               event.stopImmediatePropagation();
-              if (item.enabled()) {
+              if (item.enabled() && !(typeof item.getItems === "function")) {
                 if (item.actionIdentifier) {
                   doPerformAction(item.actionIdentifier, event);
                 } else {


### PR DESCRIPTION
1. Don't dismiss a menu panel when clicking on an item with a submenu
2. Fix the menu item background color in dark mode when the item has a submenu