### PR TITLE
Support glyph names with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- Support glyph names with spaces. [Issue 2740](https://github.com/fontra/fontra/issues/2740), [PR 2741](https://github.com/fontra/fontra/pull/2741)
 - Fix the menu item background color in dark mode when the item has a submenu; Don't dismiss a menu panel when clicking on an item with a submenu. [PR 2739](https://github.com/fontra/fontra/pull/2739)
 - Fixes behavior when a character is not encoded, but the (suggested) glyph name for it does exist in the font. [PR 2724](https://github.com/fontra/fontra/pull/2724)
 

--- a/src-js/fontra-core/src/character-lines.js
+++ b/src-js/fontra-core/src/character-lines.js
@@ -122,7 +122,7 @@ export function stringFromCharacterLines(characterLines) {
       } else if (glyphInfo.character) {
         textLine += glyphInfo.character;
       } else {
-        textLine += "/" + glyphInfo.glyphName;
+        textLine += "/" + glyphInfo.glyphName.replaceAll(" ", "\\ ");
         if (characterLine[i + 1]?.character) {
           textLine += " ";
         }
@@ -165,7 +165,7 @@ function characterFromGlyphName(
   return character;
 }
 
-const glyphNameEndRE = /[//\s]/g;
+const glyphNameEndRE = /(\/)|((?<!\\)\s)/g;
 
 function parseGlyphName(string, i) {
   let glyphName;
@@ -186,6 +186,8 @@ function parseGlyphName(string, i) {
       i = j;
     }
   }
+
+  glyphName = glyphName.replaceAll("\\ ", " ");
 
   return { glyphName, i };
 }

--- a/src-js/fontra-core/tests/test-character-lines.js
+++ b/src-js/fontra-core/tests/test-character-lines.js
@@ -111,6 +111,10 @@ describe("character-lines", () => {
       input: "/Nonstandard.with.ext",
       expectedLines: [[{ character: undefined, glyphName: "Nonstandard.with.ext" }]],
     },
+    {
+      input: "/glyphname\\ with\\ spaces",
+      expectedLines: [[{ character: undefined, glyphName: "glyphname with spaces" }]],
+    },
   ];
 
   const fallbackGlyphMap = { "outlier": [ord("$")], "Nonstandard.with.ext": [] };
@@ -159,6 +163,10 @@ describe("character-lines", () => {
       expectedOutput: "/?/A",
     },
     { input: [[{ character: "R", glyphName: "outlier" }]], expectedOutput: "R" },
+    {
+      input: [[{ character: null, glyphName: "glyphname with spaces" }]],
+      expectedOutput: "/glyphname\\ with\\ spaces",
+    },
   ];
 
   parametrize(

--- a/src-js/views-editor/src/editor.js
+++ b/src-js/views-editor/src/editor.js
@@ -3101,7 +3101,9 @@ export class EditorController extends ViewController {
     switch (await theDialog.run()) {
       case "copy": {
         const glyphNamesString = chunks(usedBy, 16)
-          .map((chunked) => chunked.map((glyphName) => "/" + glyphName).join(""))
+          .map((chunked) =>
+            chunked.map((glyphName) => "/" + glyphName.replaceAll(" ", "\\ ")).join("")
+          )
           .join("\n");
         const clipboardObject = {
           "text/plain": glyphNamesString,

--- a/src-js/views-fontoverview/src/fontoverview.js
+++ b/src-js/views-fontoverview/src/fontoverview.js
@@ -969,7 +969,7 @@ function openGlyphsInEditor(
       viewInfo.text +=
         0x002f === codePoints[0] ? "//" : String.fromCodePoint(codePoints[0]);
     } else {
-      viewInfo.text += `/${glyphName}`;
+      viewInfo.text += `/${glyphName.replaceAll(" ", "\\ ")}`;
     }
   }
 


### PR DESCRIPTION
Improve support for glyphs with spaces in their names by allowing backslash-space in the /glyphname notation, for example `/glyphname\ with\ spaces`.

This fixes #2740.