### PR TITLE
[kerning tool] Validate misc state for kerning

### DIFF
--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -188,6 +188,10 @@ export const strings = {
     "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "Der Glyph ist gesperrt.",
   "dialog.cant-edit-glyph.title": "Kann Glyphen “%0” nicht bearbeiten",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
   "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "Erstellen",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -187,6 +187,10 @@ export const strings = {
     "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "The glyph is locked.",
   "dialog.cant-edit-glyph.title": "Can’t edit glyph “%0”",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
   "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "Create",

--- a/src-js/fontra-core/assets/lang/es-419.js
+++ b/src-js/fontra-core/assets/lang/es-419.js
@@ -196,6 +196,10 @@ export const strings = {
     "La ubicación no corresponde a una matriz para los siguientes glifos: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "El glifo está bloqueado.",
   "dialog.cant-edit-glyph.title": 'No se puede editar el glifo "%0"',
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "No se puede editar el kerning",
   "dialog.cant-edit-sidebearings.title": "No se pueden editar los márgenes laterales",
   "dialog.create": "Crear",

--- a/src-js/fontra-core/assets/lang/es-ES.js
+++ b/src-js/fontra-core/assets/lang/es-ES.js
@@ -196,6 +196,10 @@ export const strings = {
     "La ubicación no corresponde a una matriz para los siguientes glifos: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "El glifo está bloqueado.",
   "dialog.cant-edit-glyph.title": 'No se puede editar el glifo "%0"',
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "No se puede editar el kerning",
   "dialog.cant-edit-sidebearings.title": "No se pueden editar los márgenes laterales",
   "dialog.create": "Crear",

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -188,6 +188,10 @@ export const strings = {
     "L'emplacement n'est pas sur une source pour les glyphes suivants : %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "Le glyphe est verrouillé.",
   "dialog.cant-edit-glyph.title": "Ce n'est pas possible de modifier le glyphe «%0»",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Ce n'est pas possible de modifier le crénage",
   "dialog.cant-edit-sidebearings.title":
     "Ce n'est pas possible de modifier les approches",

--- a/src-js/fontra-core/assets/lang/it.js
+++ b/src-js/fontra-core/assets/lang/it.js
@@ -194,6 +194,10 @@ export const strings = {
     "La posizione non si trova su una sorgente per i seguenti glifi: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "Il glifo è bloccato.",
   "dialog.cant-edit-glyph.title": "Non è possibile modificare il glifo “%0”",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Non è possibile modificare la crenatura",
   "dialog.cant-edit-sidebearings.title":
     "Non è possibile modificare gli spazi laterali",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -187,6 +187,10 @@ export const strings = {
     "The location is not at a source for the following glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "このグリフはロックされています。",
   "dialog.cant-edit-glyph.title": "グリフ“%0”を編集できませんでした。",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Can’t edit kerning",
   "dialog.cant-edit-sidebearings.title": "Can’t edit sidebearings",
   "dialog.create": "作成",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -188,6 +188,10 @@ export const strings = {
     "De locatie is niet op een source voor de volgende glyphs: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "De glyph is vergrendeld",
   "dialog.cant-edit-glyph.title": "Kan glyph %0 niet bewerken",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Kan kerning niet bewerken",
   "dialog.cant-edit-sidebearings.title": "Kan marges niet bewerken",
   "dialog.create": "Creëer",

--- a/src-js/fontra-core/assets/lang/pt-BR.js
+++ b/src-js/fontra-core/assets/lang/pt-BR.js
@@ -196,6 +196,10 @@ export const strings = {
     "O local não é de uma matriz para os seguintes glifos: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "O glifo está bloqueado.",
   "dialog.cant-edit-glyph.title": 'Não é possível editar o glifo "%0"',
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Não é possível editar o kerning",
   "dialog.cant-edit-sidebearings.title": "Não é possível editar as margens laterais",
   "dialog.create": "Criar",

--- a/src-js/fontra-core/assets/lang/pt-PT.js
+++ b/src-js/fontra-core/assets/lang/pt-PT.js
@@ -196,6 +196,10 @@ export const strings = {
     "O local não é de uma matriz para os seguintes glifos: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "O glifo está bloqueado.",
   "dialog.cant-edit-glyph.title": 'Não é possível editar o glifo "%0"',
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Não é possível editar o kerning",
   "dialog.cant-edit-sidebearings.title": "Não é possível editar as margens laterais",
   "dialog.create": "Criar",

--- a/src-js/fontra-core/assets/lang/ru.js
+++ b/src-js/fontra-core/assets/lang/ru.js
@@ -188,6 +188,10 @@ export const strings = {
     "Положение не соответствует мастеру для следующих глифов: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "Глиф заблокирован.",
   "dialog.cant-edit-glyph.title": "Не удается править глиф «%0»",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Не удается править кернинг",
   "dialog.cant-edit-sidebearings.title": "Не удается править полуапроши",
   "dialog.create": "Создать",

--- a/src-js/fontra-core/assets/lang/tl.js
+++ b/src-js/fontra-core/assets/lang/tl.js
@@ -188,6 +188,10 @@ export const strings = {
     "Ang lokasyon ay wala sa pinagmulan para sa mga sumusunod na glyph: %0",
   "dialog.cant-edit-glyph.content.locked-glyph": "Naka-lock ang gliph.",
   "dialog.cant-edit-glyph.title": "Hindi ma-edit ang gliph na “%0”",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "Hindi ma-edit ang kerning",
   "dialog.cant-edit-sidebearings.title": "Hindi ma-edit ang mga sidebearing",
   "dialog.create": "Gumawa",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -182,6 +182,10 @@ export const strings = {
     "以下字形的当前位置不是一个源：%0",
   "dialog.cant-edit-glyph.content.locked-glyph": "该字形已被锁定。",
   "dialog.cant-edit-glyph.title": "无法编辑字形 “%0”",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "无法编辑字偶距",
   "dialog.cant-edit-sidebearings.title": "无法编辑字边距",
   "dialog.create": "创建",

--- a/src-js/fontra-core/assets/lang/zh-TW.js
+++ b/src-js/fontra-core/assets/lang/zh-TW.js
@@ -182,6 +182,10 @@ export const strings = {
     "以下字形的目前位置不是一個源：%0",
   "dialog.cant-edit-glyph.content.locked-glyph": "此字形已鎖定。",
   "dialog.cant-edit-glyph.title": "無法編輯字形「%0」",
+  "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
+    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+  "dialog.cant-edit-kerning.content.manually-written-feature":
+    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
   "dialog.cant-edit-kerning.title": "無法編輯字偶距",
   "dialog.cant-edit-sidebearings.title": "無法編輯字邊距",
   "dialog.create": "建立",

--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -1143,6 +1143,11 @@ class KerningTool extends MetricsBaseTool {
       return {};
     }
 
+    if (!this.sceneSettings.applyTextShaping) {
+      this.showDialogTextShapingOff();
+      return {};
+    }
+
     const pairSelectors = [];
     const values = [];
     for (const handle of this.selectedHandles) {
@@ -1205,6 +1210,28 @@ class KerningTool extends MetricsBaseTool {
     );
     if (result === "goToNearestSource") {
       this.editor.goToNearestSource(false);
+    }
+  }
+
+  async showDialogTextShapingOff() {
+    const result = await dialog(
+      translate("dialog.cant-edit-kerning.title"),
+      translate("dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on"),
+      [
+        {
+          title: translate("dialog.cancel"),
+          resultValue: "cancel",
+          isCancelButton: true,
+        },
+        {
+          title: translate("dialog.yes"),
+          resultValue: "turn-on",
+          isDefaultButton: true,
+        },
+      ]
+    );
+    if (result === "turn-on") {
+      this.sceneSettings.applyTextShaping = true;
     }
   }
 

--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -1154,10 +1154,7 @@ class KerningTool extends MetricsBaseTool {
       shaper.getFeatureInfo("GPOS")["kern"] &&
       !shaper.insertMarkers.find((item) => item.tag === "kern")
     ) {
-      message(
-        translate("dialog.cant-edit-kerning.title"),
-        translate("dialog.cant-edit-kerning.content.manually-written-feature")
-      );
+      this.showDialogManualKernFeature();
       return {};
     }
 
@@ -1246,6 +1243,13 @@ class KerningTool extends MetricsBaseTool {
     if (result === "turn-on") {
       this.sceneSettings.applyTextShaping = true;
     }
+  }
+
+  showDialogManualKernFeature() {
+    message(
+      translate("dialog.cant-edit-kerning.title"),
+      translate("dialog.cant-edit-kerning.content.manually-written-feature")
+    );
   }
 
   getSourceIdentifier() {

--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -1084,7 +1084,7 @@ class KerningTool extends MetricsBaseTool {
       return;
     }
 
-    const { editContext, values } = this.getEditContext();
+    const { editContext, values } = await this.getEditContext();
     if (!editContext) {
       return;
     }
@@ -1123,7 +1123,7 @@ class KerningTool extends MetricsBaseTool {
 
     deltaX *= this.getStepValue(event);
 
-    const { editContext, values } = this.getEditContext();
+    const { editContext, values } = await this.getEditContext();
     if (!editContext) {
       return;
     }
@@ -1136,7 +1136,7 @@ class KerningTool extends MetricsBaseTool {
     this.pushUndoItem(changes, undoLabel);
   }
 
-  getEditContext(wantValues = true) {
+  async getEditContext(wantValues = true) {
     const sourceIdentifier = this.getSourceIdentifier();
     if (!sourceIdentifier && wantValues) {
       this.showDialogLocationNotAtSource();
@@ -1300,7 +1300,7 @@ class KerningTool extends MetricsBaseTool {
   }
 
   async deleteSelectedKerningPairs(forThisSource) {
-    const { editContext, values } = this.getEditContext(forThisSource);
+    const { editContext, values } = await this.getEditContext(forThisSource);
     if (!editContext) {
       return;
     }

--- a/src-js/views-editor/src/edit-tools-metrics.js
+++ b/src-js/views-editor/src/edit-tools-metrics.js
@@ -1148,6 +1148,19 @@ class KerningTool extends MetricsBaseTool {
       return {};
     }
 
+    const shaper = this.sceneSettings.shaper;
+
+    if (
+      shaper.getFeatureInfo("GPOS")["kern"] &&
+      !shaper.insertMarkers.find((item) => item.tag === "kern")
+    ) {
+      message(
+        translate("dialog.cant-edit-kerning.title"),
+        translate("dialog.cant-edit-kerning.content.manually-written-feature")
+      );
+      return {};
+    }
+
     const pairSelectors = [];
     const values = [];
     for (const handle of this.selectedHandles) {


### PR DESCRIPTION
Refuse to edit kerning:
- When the "Apply text shaping and features" is option is off
- When there's a manually written `kern` OT feature without an insertion marker (that will override any kerning data in the font)

This fixes #2692.