### PR TITLE
Fix text align change when in auto-view-box mode

### DIFF
--- a/src-js/views-editor/src/scene-controller.js
+++ b/src-js/views-editor/src/scene-controller.js
@@ -715,7 +715,11 @@ export class SceneController {
 
     const [minX, maxX] = this.sceneModel.getTextHorizontalExtents();
 
-    if (this.scrollAdjustBehavior === "text-align" && this._previousTextExtents) {
+    if (
+      this.scrollAdjustBehavior === "text-align" &&
+      this._previousTextExtents &&
+      !this.autoViewBox
+    ) {
       const [minXPre, maxXPre] = this._previousTextExtents;
       originXDelta = minX - minXPre;
     } else if (


### PR DESCRIPTION
Don't use 'text-align' scroll adjust when in autoViewBox mode: autoViewBox will take care of it then.