### PR TITLE
Ensure various font info can't be edited when in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Improvements
 
+- [font info] Make sure various font info can't be edited when in read-only mode. [PR 2759](https://github.com/fontra/fontra/pull/2759)
 - [shaping debugger] Make showing kerning as part of the advance width field opt-out. [Issue 2522](https://github.com/fontra/fontra/issues/2522), [PR 2749](https://github.com/fontra/fontra/pull/2749)
 
 ## 2026-08-29 [version 2026.8.0]

--- a/src-js/fontra-core/assets/css/core.css
+++ b/src-js/fontra-core/assets/css/core.css
@@ -164,6 +164,14 @@ icon-button {
 }
 
 #fontra-project-name {
+  display: flex;
+  gap: 0.2em;
+  align-content: center;
   font-size: 1.2em;
   margin-right: 1em;
+}
+
+#fontra-project-name > inline-svg {
+  width: 1em;
+  transform: translateY(0.08em);
 }

--- a/src-js/fontra-core/assets/lang/de.js
+++ b/src-js/fontra-core/assets/lang/de.js
@@ -181,6 +181,7 @@ export const strings = {
   "dialog.add": "Hinzufügen",
   "dialog.cancel": "Abbrechen",
   "dialog.cant-create-glyph.title": "Kann Glyphen “%0” nicht erstellen",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Der Font ist schreibgeschützt.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "Die Location ist nicht bei einer Source.",

--- a/src-js/fontra-core/assets/lang/en.js
+++ b/src-js/fontra-core/assets/lang/en.js
@@ -180,6 +180,7 @@ export const strings = {
   "dialog.add": "Add",
   "dialog.cancel": "Cancel",
   "dialog.cant-create-glyph.title": "Can’t create glyph “%0”",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "The font is read-only.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "The location is not at a source.",

--- a/src-js/fontra-core/assets/lang/es-419.js
+++ b/src-js/fontra-core/assets/lang/es-419.js
@@ -189,6 +189,7 @@ export const strings = {
   "dialog.add": "Agregar",
   "dialog.cancel": "Cancelar",
   "dialog.cant-create-glyph.title": 'No se puede crear el glifo "%0"',
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "La fuente es de solo lectura.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "La ubicación no corresponde a una matriz.",

--- a/src-js/fontra-core/assets/lang/es-ES.js
+++ b/src-js/fontra-core/assets/lang/es-ES.js
@@ -189,6 +189,7 @@ export const strings = {
   "dialog.add": "Añadir",
   "dialog.cancel": "Cancelar",
   "dialog.cant-create-glyph.title": 'No se puede crear el glifo "%0"',
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "La fuente es de solo lectura.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "La ubicación no corresponde a una matriz.",

--- a/src-js/fontra-core/assets/lang/fr.js
+++ b/src-js/fontra-core/assets/lang/fr.js
@@ -181,6 +181,7 @@ export const strings = {
   "dialog.add": "Ajouter",
   "dialog.cancel": "Annuler",
   "dialog.cant-create-glyph.title": "Ce n'est pas possible de créer le glyphe «%0»",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Cette police est en lecture seule.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "L'emplacement n'est pas sur une source.",

--- a/src-js/fontra-core/assets/lang/it.js
+++ b/src-js/fontra-core/assets/lang/it.js
@@ -187,6 +187,7 @@ export const strings = {
   "dialog.add": "Aggiungi",
   "dialog.cancel": "Annulla",
   "dialog.cant-create-glyph.title": "Non è possibile creare il glifo “%0”",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Il font è in sola lettura.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "La posizione non si trova su una sorgente.",

--- a/src-js/fontra-core/assets/lang/ja.js
+++ b/src-js/fontra-core/assets/lang/ja.js
@@ -180,6 +180,7 @@ export const strings = {
   "dialog.add": "追加",
   "dialog.cancel": "キャンセル",
   "dialog.cant-create-glyph.title": "グリフ“%0”を作成できませんでした。",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "このフォントは読み取り専用です。",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "現在の補完軸の値はソースと異なります。",

--- a/src-js/fontra-core/assets/lang/nl.js
+++ b/src-js/fontra-core/assets/lang/nl.js
@@ -181,6 +181,7 @@ export const strings = {
   "dialog.add": "Voeg toe",
   "dialog.cancel": "Annuleren",
   "dialog.cant-create-glyph.title": "Kan glyph %0 niet aanmaken",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Het font is read-only",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "De locatie is niet op een source",

--- a/src-js/fontra-core/assets/lang/pt-BR.js
+++ b/src-js/fontra-core/assets/lang/pt-BR.js
@@ -189,6 +189,7 @@ export const strings = {
   "dialog.add": "Adicionar",
   "dialog.cancel": "Cancelar",
   "dialog.cant-create-glyph.title": 'Não é possível criar o glifo "%0"',
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Essa fonte é somente leitura.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "O local não é de uma matriz",

--- a/src-js/fontra-core/assets/lang/pt-PT.js
+++ b/src-js/fontra-core/assets/lang/pt-PT.js
@@ -189,6 +189,7 @@ export const strings = {
   "dialog.add": "Adicionar",
   "dialog.cancel": "Cancelar",
   "dialog.cant-create-glyph.title": 'Não é possível criar o glifo "%0"',
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Essa fonte é somente leitura.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "O local não é de uma matriz",

--- a/src-js/fontra-core/assets/lang/ru.js
+++ b/src-js/fontra-core/assets/lang/ru.js
@@ -181,6 +181,7 @@ export const strings = {
   "dialog.add": "Добавить",
   "dialog.cancel": "Отменить",
   "dialog.cant-create-glyph.title": "Не удается создать глиф «%0»",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Этот шрифт только для чтения.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "Положение не соответствует ни одному мастеру.",
@@ -189,9 +190,9 @@ export const strings = {
   "dialog.cant-edit-glyph.content.locked-glyph": "Глиф заблокирован.",
   "dialog.cant-edit-glyph.title": "Не удается править глиф «%0»",
   "dialog.cant-edit-kerning.content.apply-text-shaping-must-be-on":
-    'The "Apply text shaping and features" option must be on. Would you like to turn it on?',
+    "Опция «Применить формирование текста и фичи» должна быть включена. Хотите включить её?",
   "dialog.cant-edit-kerning.content.manually-written-feature":
-    "There is a manually written 'kern' OpenType feature without an \"# Automatic Code\" insertion marker.",
+    "Обнаружена созданная вручную фича OpenType «kern» без маркера вставки «# Automatic Code»",
   "dialog.cant-edit-kerning.title": "Не удается править кернинг",
   "dialog.cant-edit-sidebearings.title": "Не удается править полуапроши",
   "dialog.create": "Создать",
@@ -351,9 +352,9 @@ export const strings = {
   "sidebar.characters-glyphs.input-characters": "Входные знаки",
   "sidebar.characters-glyphs.output-glyphs": "Выходные глифы",
   "sidebar.characters-glyphs.output-glyphs.options-menu-tooltip":
-    "Output glyphs display options",
+    "Параметры отображения выходных глифов",
   "sidebar.characters-glyphs.output-glyphs.show-kerning-for-advance":
-    "Show kerning in Advance column",
+    "Показывать кернинг в столбце «Ширина»",
   "sidebar.characters-glyphs.shaping-debugger": "Отладчик формирования",
   "sidebar.characters-glyphs.shaping-debugger.options-menu-tooltip":
     "Параметры отладчика формирования текста",

--- a/src-js/fontra-core/assets/lang/tl.js
+++ b/src-js/fontra-core/assets/lang/tl.js
@@ -181,6 +181,7 @@ export const strings = {
   "dialog.add": "Idagdag",
   "dialog.cancel": "Kanselahin",
   "dialog.cant-create-glyph.title": "Hindi makagawa ng glyph na “%0”",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "Read-only ang font.",
   "dialog.cant-edit-glyph.content.location-not-at-source":
     "Ang lokasyon ay wala sa isang pinagmumulan.",

--- a/src-js/fontra-core/assets/lang/zh-CN.js
+++ b/src-js/fontra-core/assets/lang/zh-CN.js
@@ -176,6 +176,7 @@ export const strings = {
   "dialog.add": "添加",
   "dialog.cancel": "取消",
   "dialog.cant-create-glyph.title": "无法添加字形 “%0”",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "该字体为只读文件。",
   "dialog.cant-edit-glyph.content.location-not-at-source": "当前位置不是一个源。",
   "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":

--- a/src-js/fontra-core/assets/lang/zh-TW.js
+++ b/src-js/fontra-core/assets/lang/zh-TW.js
@@ -176,6 +176,7 @@ export const strings = {
   "dialog.add": "新增",
   "dialog.cancel": "取消",
   "dialog.cant-create-glyph.title": "無法建立字形「%0」",
+  "dialog.cant-edit-font.title": "Can't make changes",
   "dialog.cant-edit-glyph.content": "此字型檔為唯讀。",
   "dialog.cant-edit-glyph.content.location-not-at-source": "目前位置不是一個源。",
   "dialog.cant-edit-glyph.content.location-not-at-source-for-glyphs":

--- a/src-js/fontra-core/src/view-controller.js
+++ b/src-js/fontra-core/src/view-controller.js
@@ -1,5 +1,6 @@
 import * as html from "@fontra/core/html-utils.js";
 import { ensureLanguageHasLoaded } from "@fontra/core/localization.js";
+import { InlineSVG } from "@fontra/web-components/inline-svg.js";
 import { dialog, dialogSetup, message } from "@fontra/web-components/modal-dialog.js";
 import { registerAction } from "./actions.js";
 import { Backend } from "./backend-api.js";
@@ -76,7 +77,13 @@ export class ViewController {
     document.title = this.constructor.titlePattern(projectName);
 
     const topBar = document.querySelector(".top-bar-container");
-    topBar?.appendChild(html.div({ id: "fontra-project-name" }, [projectName]));
+
+    topBar?.appendChild(
+      html.div({ id: "fontra-project-name" }, [
+        this.fontController.readOnly ? new InlineSVG("/tabler-icons/lock.svg") : "",
+        projectName,
+      ])
+    );
 
     for (const format of this.fontController.backendInfo.projectManagerFeatures[
       "export-as"

--- a/src-js/fontra-webcomponents/src/custom-data-list.js
+++ b/src-js/fontra-webcomponents/src/custom-data-list.js
@@ -121,7 +121,7 @@ export class CustomDataList extends SimpleElement {
         return { ...customData };
       });
       model.customData = newCustomData;
-      addRemoveButton.scrollIntoView({
+      this.addRemoveButton.scrollIntoView({
         behavior: "auto",
         block: "nearest",
         inline: "nearest",
@@ -130,7 +130,7 @@ export class CustomDataList extends SimpleElement {
     };
 
     labelList.addEventListener("deleteKey", deleteSelectedItem);
-    const addRemoveButton = html.createDomElement("add-remove-buttons", {
+    this.addRemoveButton = html.createDomElement("add-remove-buttons", {
       addButtonCallback: async () => {
         const currentKeys = labelList.items.map((customData) => {
           return customData.key;
@@ -151,7 +151,7 @@ export class CustomDataList extends SimpleElement {
         labelList.setItems(newItems);
         const itemIndex = newItems.indexOf(newItem);
         labelList.editCell(itemIndex, "key");
-        addRemoveButton.scrollIntoView({
+        this.addRemoveButton.scrollIntoView({
           behavior: "auto",
           block: "nearest",
           inline: "nearest",
@@ -161,11 +161,11 @@ export class CustomDataList extends SimpleElement {
       disableRemoveButton: true,
     });
 
-    updateRemoveButton(labelList, addRemoveButton);
+    updateRemoveButton(labelList, this.addRemoveButton);
 
     return html.div({ style: "display: grid; grid-gap: 0.3em;" }, [
       labelList,
-      addRemoveButton,
+      this.addRemoveButton,
     ]);
   }
 

--- a/src-js/views-fontinfo/src/panel-axes.js
+++ b/src-js/views-fontinfo/src/panel-axes.js
@@ -17,7 +17,7 @@ import "@fontra/web-components/add-remove-buttons.js";
 import { IconButton } from "@fontra/web-components/icon-button.js"; // for <icon-button>
 import { dialogSetup } from "@fontra/web-components/modal-dialog.js";
 import { UIList } from "@fontra/web-components/ui-list.js";
-import { BaseInfoPanel } from "./panel-base.js";
+import { showDialogCannotEditReadOnly, BaseInfoPanel } from "./panel-base.js";
 
 const presetAxes = [
   {
@@ -84,11 +84,18 @@ export class AxesPanel extends BaseInfoPanel {
     const axes = this.fontController.axes;
     for (const index of range(axes.axes.length)) {
       axisContainer.appendChild(
-        new AxisBox(axes, index, this.postChange.bind(this), this.deleteAxis.bind(this))
+        new AxisBox(
+          axes,
+          index,
+          this.postChange.bind(this),
+          this.deleteAxis.bind(this),
+          this.fontController.readOnly
+        )
       );
     }
-
-    setupSortableList(axisContainer);
+    if (!this.fontController.readOnly) {
+      setupSortableList(axisContainer);
+    }
 
     axisContainer.addEventListener("reordered", (event) => {
       const reorderedAxes = [];
@@ -117,6 +124,11 @@ export class AxesPanel extends BaseInfoPanel {
   }
 
   async newAxis() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const dialog = await dialogSetup(translate("axes.create"), "", [
       { title: translate("dialog.cancel"), isCancelButton: true },
       { title: translate("axes.add"), resultValue: "ok", isDefaultButton: true },
@@ -228,6 +240,11 @@ export class AxesPanel extends BaseInfoPanel {
   }
 
   async deleteAxis(axisIndex) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const undoLabel = translate(
       "axes.undo.delete",
       this.fontController.axes.axes[axisIndex].name
@@ -298,14 +315,15 @@ select {
 `);
 
 class AxisBox extends HTMLElement {
-  constructor(axes, axisIndex, postChange, deleteAxis) {
+  constructor(axes, axisIndex, postChange, deleteAxis, readOnly) {
     super();
     this.classList.add("fontra-ui-font-info-axes-panel-axis-box");
-    this.draggable = true;
+    this.draggable = !readOnly;
     this.axes = axes;
     this.axisIndex = axisIndex;
     this.postChange = postChange;
     this.deleteAxis = deleteAxis;
+    this.readOnly = readOnly;
     this._updateContents();
   }
 
@@ -314,6 +332,12 @@ class AxisBox extends HTMLElement {
   }
 
   editAxis(editFunc, undoLabel) {
+    if (this.readOnly) {
+      showDialogCannotEditReadOnly();
+      this._updateContents();
+      return;
+    }
+
     const root = { axes: this.axes };
     const changes = recordChanges(root, (root) => {
       editFunc(root.axes.axes[this.axisIndex]);
@@ -324,6 +348,12 @@ class AxisBox extends HTMLElement {
   }
 
   replaceAxis(newAxis, undoLabel) {
+    if (this.readOnly) {
+      showDialogCannotEditReadOnly();
+      this._updateContents();
+      return;
+    }
+
     const root = { axes: this.axes };
     const changes = recordChanges(root, (root) => {
       root.axes.axes[this.axisIndex] = newAxis;

--- a/src-js/views-fontinfo/src/panel-base.js
+++ b/src-js/views-fontinfo/src/panel-base.js
@@ -7,6 +7,7 @@ import * as html from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { MultiPanelBasePanel } from "@fontra/core/multi-panel.js";
 import { commandKeyProperty, sleepAsync } from "@fontra/core/utils.ts";
+import { message } from "@fontra/web-components/modal-dialog.js";
 
 export class BaseInfoPanel extends MultiPanelBasePanel {
   constructor(viewController, panelElement) {
@@ -114,4 +115,11 @@ export class BaseInfoPanel extends MultiPanelBasePanel {
     // TODO handle error
     this.fontController.notifyEditListeners("editFinal", this);
   }
+}
+
+export async function showDialogCannotEditReadOnly() {
+  await message(
+    translate("dialog.cant-edit-font.title"),
+    translate("dialog.cant-edit-glyph.content")
+  );
 }

--- a/src-js/views-fontinfo/src/panel-conditional-substitutions.js
+++ b/src-js/views-fontinfo/src/panel-conditional-substitutions.js
@@ -15,7 +15,7 @@ import {
 import { assert, compare, enumerate, range } from "@fontra/core/utils.ts";
 import { askString } from "@fontra/web-components/modal-dialog.js";
 import { mapAxesFromUserSpaceToSourceSpace } from "@fontra/core/var-model.js";
-import { BaseInfoPanel } from "./panel-base.js";
+import { showDialogCannotEditReadOnly, BaseInfoPanel } from "./panel-base.js";
 
 const glyphNamesOptionsId =
   "fontra-ui-font-info-conditional-substitutions-glyph-names-options";
@@ -222,6 +222,11 @@ export class ConditionalSubstitutionsPanel extends BaseInfoPanel {
   }
 
   newRule() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     this.editConditionalSubstitutions((conditionalSubstitutions) => {
       conditionalSubstitutions.rules.push({
         name: "",

--- a/src-js/views-fontinfo/src/panel-conditional-substitutions.js
+++ b/src-js/views-fontinfo/src/panel-conditional-substitutions.js
@@ -100,7 +100,9 @@ export class ConditionalSubstitutionsPanel extends BaseInfoPanel {
       );
     }
 
-    setupSortableList(container);
+    if (!this.fontController.readOnly) {
+      setupSortableList(container);
+    }
 
     container.addEventListener("reordered", (event) => {
       const reordered = [];
@@ -201,6 +203,12 @@ export class ConditionalSubstitutionsPanel extends BaseInfoPanel {
           value: "custom",
           getLabel: getCustomLabel,
           callback: async () => {
+            if (this.fontController.readOnly) {
+              showDialogCannotEditReadOnly();
+              this.setupUI();
+              return;
+            }
+
             const answer = await askString(
               translate(
                 "conditional-substitutions.rule-processing.feature-tags.enter.title"
@@ -238,6 +246,12 @@ export class ConditionalSubstitutionsPanel extends BaseInfoPanel {
   }
 
   editConditionalSubstitutions(editFunc, undoLabel) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this.setupUI();
+      return;
+    }
+
     const root = {
       conditionalSubstitutions: this.conditionalSubstitutions,
     };
@@ -251,6 +265,11 @@ export class ConditionalSubstitutionsPanel extends BaseInfoPanel {
   }
 
   async replaceRules(updatedRules, undoLabel) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const root = {
       conditionalSubstitutions: this.conditionalSubstitutions,
     };
@@ -432,7 +451,7 @@ class RuleBox extends HTMLElement {
       "fontra-ui-font-info-conditional-substitutions-panel-conditional-substitutions-rule-box"
     );
 
-    this.draggable = true;
+    this.draggable = !fontController.readOnly;
     this.fontController = fontController;
     this.fontAxesSourceSpace = fontAxesSourceSpace;
     this.conditionalSubstitutions = conditionalSubstitutions;
@@ -445,6 +464,12 @@ class RuleBox extends HTMLElement {
   }
 
   editRule(editFunc, undoLabel) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this._updateContents();
+      return;
+    }
+
     const root = {
       conditionalSubstitutions: this.conditionalSubstitutions,
     };
@@ -458,6 +483,11 @@ class RuleBox extends HTMLElement {
   }
 
   deleteRule() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const undoLabel = translate("conditional-substitutions.rule.undo-remove");
     const root = {
       conditionalSubstitutions: this.conditionalSubstitutions,
@@ -810,10 +840,13 @@ class RuleBox extends HTMLElement {
       .flat();
 
     elements.push(
-      makePlusButton(
-        () => this._updateContents({ addNewSubstitution: true }),
-        "conditional-substitutions.substitutions.new"
-      )
+      makePlusButton(() => {
+        if (this.fontController.readOnly) {
+          showDialogCannotEditReadOnly();
+          return;
+        }
+        this._updateContents({ addNewSubstitution: true });
+      }, "conditional-substitutions.substitutions.new")
     );
 
     if (options.addNewSubstitution) {

--- a/src-js/views-fontinfo/src/panel-cross-axis-mapping.js
+++ b/src-js/views-fontinfo/src/panel-cross-axis-mapping.js
@@ -12,7 +12,7 @@ import { enumerate, range } from "@fontra/core/utils.ts";
 import { mapAxesFromUserSpaceToSourceSpace } from "@fontra/core/var-model.js";
 import "@fontra/web-components/add-remove-buttons.js";
 import "@fontra/web-components/designspace-location.js";
-import { BaseInfoPanel } from "./panel-base.js";
+import { showDialogCannotEditReadOnly, BaseInfoPanel } from "./panel-base.js";
 
 const cardsInfos = {};
 
@@ -63,7 +63,9 @@ export class CrossAxisMappingPanel extends BaseInfoPanel {
       );
     }
 
-    setupSortableList(container);
+    if (!this.fontController.readOnly) {
+      setupSortableList(container);
+    }
 
     container.addEventListener("reordered", (event) => {
       const reordered = [];
@@ -101,6 +103,11 @@ export class CrossAxisMappingPanel extends BaseInfoPanel {
   }
 
   async newCrossAxisMapping() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     //new empty mapping
     const newMapping = {
       inputLocation: {},
@@ -225,7 +232,7 @@ class CrossAxisMappingBox extends HTMLElement {
     this.classList.add(
       "fontra-ui-font-info-cross-axis-mapping-panel-cross-axis-mapping-box"
     );
-    this.draggable = true;
+    this.draggable = !fontController.readOnly;
     this.fontController = fontController;
     this.fontAxesSourceSpace = fontAxesSourceSpace;
     this.mappings = mappings;
@@ -268,6 +275,12 @@ class CrossAxisMappingBox extends HTMLElement {
   }
 
   editCrossAxisMapping(editFunc, undoLabel) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this.setupUI();
+      return;
+    }
+
     const root = { axes: this.fontController.axes };
     const changes = recordChanges(root, (root) => {
       editFunc(root.axes.mappings[this.mappingIndex]);
@@ -278,6 +291,11 @@ class CrossAxisMappingBox extends HTMLElement {
   }
 
   deleteCrossAxisMapping() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const undoLabel = translate("cross-axis-mapping.undo.delete");
     const root = { axes: this.fontController.axes };
     const changes = recordChanges(root, (root) => {

--- a/src-js/views-fontinfo/src/panel-development-status-definitions.js
+++ b/src-js/views-fontinfo/src/panel-development-status-definitions.js
@@ -4,7 +4,7 @@ import { addStyleSheet } from "@fontra/core/html-utils.js";
 import { translate } from "@fontra/core/localization.js";
 import { enumerate, hexToRgba, range, rgbaToHex } from "@fontra/core/utils.ts";
 import { message } from "@fontra/web-components/modal-dialog.js";
-import { BaseInfoPanel } from "./panel-base.js";
+import { showDialogCannotEditReadOnly, BaseInfoPanel } from "./panel-base.js";
 
 const defaultStatusFieldDefinitions = {
   "fontra.sourceStatusFieldDefinitions": [
@@ -85,6 +85,11 @@ export class DevelopmentStatusDefinitionsPanel extends BaseInfoPanel {
   }
 
   async newStatusDefinition() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const statusFieldDefinitions =
       this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
     const nextStatusValue = !statusFieldDefinitions
@@ -187,6 +192,11 @@ class StatusDefinitionBox extends HTMLElement {
   }
 
   checkStatusDefValue(statusDefValue) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return false;
+    }
+
     let errorMessage = "";
     const statusDefinitions =
       this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
@@ -213,6 +223,12 @@ class StatusDefinitionBox extends HTMLElement {
   }
 
   replaceStatusDef(newStatusDef) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this._updateContents();
+      return;
+    }
+
     const undoLabel = translate("development-status-definitions.undo.change");
     const root = { customData: this.fontController.customData };
     const changes = recordChanges(root, (root) => {
@@ -226,6 +242,11 @@ class StatusDefinitionBox extends HTMLElement {
   }
 
   deleteStatusDef(statusIndex) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const undoLabel = translate(
       "development-status-definitions.undo.delete",
       `'${this.statusDef.label}'`
@@ -244,6 +265,12 @@ class StatusDefinitionBox extends HTMLElement {
   }
 
   changeStatusDefIsDefault(event) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this._updateContents();
+      return;
+    }
+
     const undoLabel = translate(
       "development-status-definitions.undo.change-is-default"
     );
@@ -271,6 +298,12 @@ class StatusDefinitionBox extends HTMLElement {
   }
 
   changeStatusDefValue(value) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this._updateContents();
+      return;
+    }
+
     const undoLabel = translate("development-status-definitions.undo.change");
     let statusDefinitions =
       this.fontController.customData["fontra.sourceStatusFieldDefinitions"];
@@ -329,6 +362,7 @@ class StatusDefinitionBox extends HTMLElement {
           };
           this.replaceStatusDef(updatedStatusDef);
         },
+        "disabled": this.fontController.readOnly,
         "data-tooltip": translate("development-status-definitions.tooltip.color"),
         "data-tooltipposition": "top",
       })

--- a/src-js/views-fontinfo/src/panel-font-info.js
+++ b/src-js/views-fontinfo/src/panel-font-info.js
@@ -107,6 +107,10 @@ export class FontInfoPanel extends BaseInfoPanel {
         ].getDefaultFunction(info),
     }));
     const customDataList = new CustomDataList(customDataController, openTypeSettings);
+    if (this.fontController.readOnly) {
+      customDataList.addRemoveButton.disableAddButton = true;
+      customDataList.addRemoveButton.disableRemoveButton = true;
+    }
     const accordion = new Accordion();
 
     accordion.appendStyle(`

--- a/src-js/views-fontinfo/src/panel-font-info.js
+++ b/src-js/views-fontinfo/src/panel-font-info.js
@@ -7,7 +7,7 @@ import { ObservableController } from "@fontra/core/observable-object.ts";
 import { CustomDataList } from "@fontra/web-components/custom-data-list.js";
 import { Accordion } from "@fontra/web-components/ui-accordion.js";
 import { Form } from "@fontra/web-components/ui-form.js";
-import { BaseInfoPanel } from "./panel-base.js";
+import { showDialogCannotEditReadOnly, BaseInfoPanel } from "./panel-base.js";
 
 const fontInfoFields = [
   // [property name, localization key, type]
@@ -139,6 +139,12 @@ export class FontInfoPanel extends BaseInfoPanel {
   }
 
   async editFontInfo(editFunc, undoLabel) {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this.setupUI();
+      return;
+    }
+
     const root = {
       fontInfo: await this.fontController.getFontInfo(),
       unitsPerEm: this.fontController.unitsPerEm,

--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -365,6 +365,8 @@ export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
             this.updateFeatureCode(update);
           }
         }),
+        EditorState.readOnly.of(this.fontController.readOnly),
+        EditorView.editable.of(!this.fontController.readOnly),
       ],
       parent: editorContainer,
     });

--- a/src-js/views-fontinfo/src/panel-sources.js
+++ b/src-js/views-fontinfo/src/panel-sources.js
@@ -38,7 +38,7 @@ import { dialogSetup, message } from "@fontra/web-components/modal-dialog.js";
 import { Accordion } from "@fontra/web-components/ui-accordion.js";
 import { UIList } from "@fontra/web-components/ui-list.js";
 import { updateRemoveButton } from "./panel-axes.js";
-import { BaseInfoPanel } from "./panel-base.js";
+import { showDialogCannotEditReadOnly, BaseInfoPanel } from "./panel-base.js";
 
 addStyleSheet(`
 .font-sources-container {
@@ -233,12 +233,18 @@ export class SourcesPanel extends BaseInfoPanel {
         this.fontAxesSourceSpace,
         await this.fontController.getSources(),
         this.selectedSourceIdentifier,
-        this.selectedSourceIdentifier === this.fontController.defaultSourceIdentifier
+        this.selectedSourceIdentifier === this.fontController.defaultSourceIdentifier,
+        this.fontController.readOnly
       )
     );
   }
 
   async deleteSource() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     if (!this.selectedSourceIdentifier) {
       return;
     }
@@ -296,6 +302,11 @@ export class SourcesPanel extends BaseInfoPanel {
   }
 
   async newSource() {
+    if (this.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      return;
+    }
+
     const newSource = await this._sourcePropertiesRunDialog();
     if (!newSource) {
       return;
@@ -554,7 +565,14 @@ addStyleSheet(`
 `);
 
 class SourceBox extends HTMLElement {
-  constructor(sourcesPanel, fontAxesSourceSpace, sources, sourceIdentifier, isDefault) {
+  constructor(
+    sourcesPanel,
+    fontAxesSourceSpace,
+    sources,
+    sourceIdentifier,
+    isDefault,
+    readOnly
+  ) {
     super();
     this.sourcesPanel = sourcesPanel;
     this.classList.add("fontra-ui-font-info-sources-panel-source-box");
@@ -562,6 +580,7 @@ class SourceBox extends HTMLElement {
     this.sources = sources;
     this.sourceIdentifier = sourceIdentifier;
     this.isDefault = isDefault;
+    this.readOnly = readOnly;
     this.controllers = {};
     this.customDataKeys = openTypeSettingsFontSourcesLevel.map((item) => item.key);
     this._updateContents();
@@ -638,6 +657,12 @@ class SourceBox extends HTMLElement {
   }
 
   editSource(editFunc, undoLabel, preChanges) {
+    if (this.sourcesPanel.fontController.readOnly) {
+      showDialogCannotEditReadOnly();
+      this._updateContents();
+      return;
+    }
+
     const root = { sources: this.sources };
     let changes = recordChanges(root, (root) => {
       editFunc(root.sources[this.sourceIdentifier]);
@@ -826,6 +851,12 @@ input {
         this.controllers.customData,
         openTypeSettings
       );
+
+      if (this.sourcesPanel.fontController.readOnly) {
+        customDataList.addRemoveButton.disableAddButton = true;
+        customDataList.addRemoveButton.disableRemoveButton = true;
+      }
+
       accordionItems.push(
         {
           label: getLabelFromKey("lineMetricsHorizontalLayout"),
@@ -838,7 +869,7 @@ input {
         {
           label: getLabelFromKey("guidelines"),
           id: "guidelines",
-          content: buildFontGuidelineList(this.controllers.guidelines),
+          content: buildFontGuidelineList(this.controllers.guidelines, this.readOnly),
           open: Object.keys(this.source.guidelines).length > 0,
         },
         {
@@ -935,7 +966,7 @@ function buildElementLineMetricsHor(controller) {
   );
 }
 
-function buildFontGuidelineList(controller) {
+function buildFontGuidelineList(controller, readOnly) {
   const model = controller.model;
 
   const makeItem = (label) => {
@@ -1042,6 +1073,11 @@ function buildFontGuidelineList(controller) {
     removeButtonCallback: deleteSelectedItem,
     disableRemoveButton: true,
   });
+
+  if (readOnly) {
+    addRemoveButton.disableAddButton = true;
+    addRemoveButton.disableRemoveButton = true;
+  }
 
   updateRemoveButton(labelList, addRemoveButton);
 


### PR DESCRIPTION
The UI gave the appearance as if editing font info (axes, sources, etc.) would work for a read-only font (for example when looking at a TTF). Add checks and a dialog to prevent confusion.

Additionally, show a lock icon in front of the project name in the top bar when the font is read-only.