### PR TITLE
[opentype features panel] Respond to glyphs being added or deleted

### DIFF
--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -295,7 +295,7 @@ const zoomFactor = 1.05;
 export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
   static title = "opentype-feature-code.title";
   static id = "opentype-feature-code-panel";
-  static fontAttributes = ["features"];
+  static fontAttributes = ["features", "glyphMap"];
 
   async setupUI() {
     this.updateFeatureCode = scheduleCalls(

--- a/src-js/views-fontinfo/src/panel-opentype-feature-code.js
+++ b/src-js/views-fontinfo/src/panel-opentype-feature-code.js
@@ -295,7 +295,7 @@ const zoomFactor = 1.05;
 export class OpenTypeFeatureCodePanel extends BaseInfoPanel {
   static title = "opentype-feature-code.title";
   static id = "opentype-feature-code-panel";
-  static fontAttributes = ["features", "glyphMap"];
+  static fontAttributes = ["features", "glyphMap", "conditionalSubstitutions"];
 
   async setupUI() {
     this.updateFeatureCode = scheduleCalls(


### PR DESCRIPTION
Make sure we subscribe to glyphMap changes, so we can respond to glyphs being added or deleted. This causes the shaper font to be compiled on glyphMap changes as it should (and already does in the editor).